### PR TITLE
Train model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -165,6 +165,7 @@ dmypy.json
 2_process/log
 2_process/tmp
 2_process/out
+3_train/out
 
 # Specific files to include
 !/notebooks/Explore_MNTOHA_temperature_observations.html

--- a/3_train.smk
+++ b/3_train.smk
@@ -4,9 +4,9 @@ configfile: "3_train/train_config.yaml"
 # Train model
 rule train_model:
     input:
-        train_data_file = "2_process/out/{data_source}/train.npz"
+        npz_filepath = "2_process/out/{data_source}/train.npz"
     output:
-        weights_file = "3_train/out/{data_source}/lstm.pt"
+        weights_filepath = "3_train/out/{data_source}/lstm.pt"
     params:
         config = config
     script:

--- a/3_train.smk
+++ b/3_train.smk
@@ -6,7 +6,8 @@ rule train_model:
     input:
         npz_filepath = "2_process/out/{data_source}/train.npz"
     output:
-        weights_filepath = "3_train/out/{data_source}/lstm.pt"
+        weights_filepath = "3_train/out/{data_source}/lstm.pt",
+        settings_filepath = "3_train/out/{data_source}/settings.npz"
     params:
         config = config
     script:

--- a/3_train.smk
+++ b/3_train.smk
@@ -7,7 +7,7 @@ rule train_model:
         npz_filepath = "2_process/out/{data_source}/train.npz"
     output:
         weights_filepath = "3_train/out/{data_source}/{run}/lstm.pt",
-        settings_filepath = "3_train/out/{data_source}/{run}/settings.npz"
+        metadata_filepath = "3_train/out/{data_source}/{run}/metadata.npz"
     params:
         config = config
     script:

--- a/3_train.smk
+++ b/3_train.smk
@@ -1,0 +1,14 @@
+
+configfile: "3_train/train_config.yaml"
+
+# Train model
+rule train_model:
+    input:
+        train_data_file = "2_process/out/{data_source}/train.npz"
+    output:
+        weights_file = "3_train/out/{data_source}/lstm.pt"
+    params:
+        config = config
+    script:
+        "3_train/src/train.py"
+

--- a/3_train.smk
+++ b/3_train.smk
@@ -6,8 +6,8 @@ rule train_model:
     input:
         npz_filepath = "2_process/out/{data_source}/train.npz"
     output:
-        weights_filepath = "3_train/out/{data_source}/lstm.pt",
-        settings_filepath = "3_train/out/{data_source}/settings.npz"
+        weights_filepath = "3_train/out/{data_source}/{run}/lstm.pt",
+        settings_filepath = "3_train/out/{data_source}/{run}/settings.npz"
     params:
         config = config
     script:

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -1,4 +1,4 @@
-# Train an LSTM and save the results with metadata
+# Train an LSTM or EA-LSTM and save the results with metadata
 
 import os
 import numpy as np
@@ -175,7 +175,7 @@ def get_model(
     concat_static
 ):
     """
-    Create LSTM torch model
+    Create LSTM or EA-LSTM torch model
     
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#refactor-using-optim
 
@@ -187,7 +187,7 @@ def get_model(
     :param initial_forget_bias: Value of the initial forget gate bias
     :param dropout: Dropout probability, from 0 to 1 (0 = don't use dropout)
     :param concat_static: If True, uses standard LSTM. Otherwise, uses EA-LSTM
-    :returns: LSTM torch model
+    :returns: LSTM or EA-LSTM torch model
 
     """
     if torch.cuda.is_available():

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -2,7 +2,7 @@ import os
 import numpy as np
 import torch
 import torch.nn as nn
-from torch.utils.data import Dataset, DataLoader
+from torch.utils.data import Dataset, DataLoader, random_split
 from torch.optim import Adam
 
 import sys
@@ -65,6 +65,25 @@ class SequenceDataset(Dataset):
         dynamic_features = self.sequences[idx, :, self.n_outputs:self.n_outputs + self.n_dynamic]
         static_features = self.sequences[idx, :, -self.n_static:]
         return dynamic_features, static_features, temperatures
+
+
+def split(dataset, fraction, seed):
+    """
+    Randomly split a dataset into two non-overlapping subsets
+
+    :param dataset: A torch.utils.data.Dataset to be split
+    :param fraction: The fraction of data samples to put in the first subset
+    :param seed: Seed for random number generator
+    :returns: Tuple of two datasets for the two subsets
+
+    """
+    # split into two subsets
+    n_total = len(dataset)
+    n_1 = int(round(n_total * fraction))
+    n_2 = n_total - n_1
+    subset_1, subset_2 = random_split(
+        dataset, [n_1, n_2], generator=torch.Generator().manual_seed(seed))
+    return subset_1, subset_2
 
 
 def get_dataloader(npz_filepath,

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -270,7 +270,7 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, verbose=False):
     for x_d, x_s, y in valid_dl:
         n_valid += torch.sum(torch.isfinite(y))
 
-    def vprint(*args):
+    def verbose_print(*args):
         # Only print if verbose is true
         if verbose:
             print(*args)
@@ -283,29 +283,29 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, verbose=False):
         model.train()
         train_loss = 0.0
         # Data is ordered as [dynamic inputs, static inputs, labels]
-        vprint('Train loss by batch')
+        verbose_print('Train loss by batch')
         for x_d, x_s, y in train_dl:
             batch_loss, batch_count = loss_batch(model, loss_func, x_d, x_s, y, opt)
 
             # Weight the batch loss based on number of observations in each batch
-            vprint(batch_loss, batch_count)
+            verbose_print(batch_loss, batch_count)
             train_loss += batch_loss * batch_count/n_train
 
         # Loss for each validation batch, with number of obs per batch
         model.eval()
-        val_loss = 0.0
-        vprint('Validation loss by batch')
+        valid_loss = 0.0
+        verbose_print('Validation loss by batch')
         with torch.no_grad():
             for x_d, x_s, y in valid_dl:
                 batch_loss, batch_count = loss_batch(model, loss_func, x_d, x_s, y)
 
                 # Weight the batch loss based on number of observations in each batch
-                vprint(batch_loss, batch_count)
-                val_loss += batch_loss * batch_count/n_valid
+                verbose_print(batch_loss, batch_count)
+                valid_loss += batch_loss * batch_count/n_valid
 
-        print(f'{epoch}: {train_loss}, {val_loss}')
+        print(f'{epoch}: {train_loss}, {valid_loss}')
         train_losses.append(train_loss)
-        valid_losses.append(val_loss)
+        valid_losses.append(valid_loss)
     return train_losses, valid_losses
 
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -293,3 +293,27 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl):
         train_losses.append(train_loss)
         valid_losses.append(val_loss)
 
+
+def save_no_overwrite(model, filepath):
+    """
+    Save torch model without overwriting an existing file
+    
+    Append a unique number to the end of the filename to avoid overwriting any
+    existing files.
+
+    :param model: PyTorch model to be saved
+    :param filepath: Path and filename to save to
+
+    """
+    # Create new directory if needed
+    directory = os.path.dirname(filepath)
+    if not os.path.exists(directory):
+        os.makedirs(directory)
+
+    root, extension = os.path.splitext(filepath)
+    suffix = 0
+    while os.path.exists(filepath):
+        suffix += 1
+        filepath = f'{root}_{suffix}{extension}'
+    torch.save(model.state_dict(), filepath)
+

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -1,10 +1,10 @@
 import os
+import numpy as np
 import torch
 import torch.nn as nn
 from torch.utils.data import Dataset, DataLoader
 from torch.optim import Adam
 
-import numpy as np
 import sys
 sys.path.insert(1, '3_model/src')
 from models import Model
@@ -14,32 +14,32 @@ class SequenceDataset(Dataset):
     """
     Custom Dataset class for sequences that include dynamic and static inputs,
     and multiple outputs
-
+    
     __len__ returns the number of sequences
     
     __getitem__ returns dynamic input features, static input features, and
     temperature observations at all depths for one sequence
+    
+    :Example:
 
-    Example:
 
     >>> npz = np.load("2_process/out/mntoha/train.npz")
+    >>> n_depths = len(npz['depths'])
     >>> n_dynamic = len(npz['dynamic_features_all'])
     >>> n_static = len(npz['static_features_all'])
-    >>> n_depths = len(npz['depths'])
     >>> data = torch.from_numpy(npz['data'])
-    >>> dataset = SequenceDataset(data, n_depths, n_dynamic, n_static)                            
+    >>> dataset = SequenceDataset(data, n_depths, n_dynamic, n_static)
     >>> # number of sequences
     >>> len(dataset)
     19069
-    >>> # dynamic features, static features, and temperatures at depths 
+    >>> # dynamic features, static features, and temperatures at depths
     >>> # for first sequence
     >>> for e in dataset[0]:
     >>>     print(e.shape)
-    >>> 
+    >>>
     torch.Size([400, 9])
     torch.Size([400, 4])
     torch.Size([400, 49])
-
     """
     def __init__(self, sequences, n_outputs, n_dynamic, n_static):
         """
@@ -50,7 +50,7 @@ class SequenceDataset(Dataset):
 
         """
         # The number of sequences is the size of the first dimension
-        self.len = sequences.shape[0]
+        self.len = len(sequences)
         self.n_outputs = n_outputs
         self.n_dynamic = n_dynamic
         self.n_static = n_static

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -381,3 +381,9 @@ def main(npz_filepath, weights_file, config):
     save_no_overwrite(model, weights_file)
 
 
+
+if __name__ == '__main__':
+    main(snakemake.input.npz_filepath,
+         snakemake.output.weights_file,
+         snakemake.params.config)
+

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -246,6 +246,11 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
         opt.step()
         opt.zero_grad()
 
+    # NaN in the loss can cause training to fail silently
+    # Better to fail loudly!
+    if not torch.isfinite(loss):
+        raise ValueError(f'Batch loss is not finite. Its value is {loss}.')
+
     # return loss, number of finite values in y
     return loss.item(), torch.sum(loss_idx).item()
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -396,6 +396,9 @@ def main(npz_filepath, weights_filepath, metadata_filepath, config):
         batch_size            integer, Number of examples per training batch
 
     """
+    # Set seed to encourage reprodicibility
+    torch.manual_seed(config['seed'])
+
     # Get objects for training
     # model, loss function, optimizer, training data loader, validation data loader
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -319,7 +319,7 @@ def save_weights(model, filepath, overwrite=True):
     torch.save(model.state_dict(), filepath)
 
 
-def main(npz_filepath, weights_file, config):
+def main(npz_filepath, weights_filepath, config):
     """
     Train a model and save the trained weights
     
@@ -327,7 +327,7 @@ def main(npz_filepath, weights_file, config):
     specified in the config dictionary. Train the model, and save its weights.
 
     :param npz_filepath: Name and path to .npz data file
-    :param weights_file: Path and filename to save weights to
+    :param weights_filepath: Path and filename to save weights to
     :param config: Dictionary of configuration settings, including:
         max_epochs            integer, Maximum number of epochs to train for
         loss_criterion        string, Name of class in torch.nn to use for loss
@@ -382,12 +382,13 @@ def main(npz_filepath, weights_file, config):
     # Training loop
     fit(config['max_epochs'], model, loss_func, optimizer, train_data_loader, valid_data_loader)
     print('Finished Training')
-    save_weights(model, weights_file, overwrite=True)
 
+    # Save model weights
+    save_weights(model, weights_filepath, overwrite=True)
 
 
 if __name__ == '__main__':
     main(snakemake.input.npz_filepath,
-         snakemake.output.weights_file,
+         snakemake.output.weights_filepath,
          snakemake.params.config)
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -291,17 +291,18 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, verbose=False):
             vprint(batch_loss, batch_count)
             train_loss += batch_loss * batch_count/n_train
 
-        model.eval()
         # Loss for each validation batch, with number of obs per batch
-        with torch.no_grad():
-            losses, nums = zip(
-                *[loss_batch(model, loss_func, x_d, x_s, y) for x_d, x_s, y in valid_dl]
-            )
+        model.eval()
+        val_loss = 0.0
         vprint('Validation loss by batch')
-        for loss, num in zip(losses, nums):
-            vprint(loss, num)
-        # Average validation loss
-        val_loss = np.sum(np.multiply(losses, nums)) / np.sum(nums)
+        with torch.no_grad():
+            for x_d, x_s, y in valid_dl:
+                batch_loss, batch_count = loss_batch(model, loss_func, x_d, x_s, y)
+
+                # Weight the batch loss based on number of observations in each batch
+                vprint(batch_loss, batch_count)
+                val_loss += batch_loss * batch_count/n_valid
+
         print(f'{epoch}: {train_loss}, {val_loss}')
         train_losses.append(train_loss)
         valid_losses.append(val_loss)

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -170,11 +170,10 @@ def get_model(
     hidden_size,
     initial_forget_bias,
     dropout,
-    concat_static,
-    learning_rate
+    concat_static
 ):
     """
-    Return LSTM model and optimizer
+    Create LSTM torch model
     
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#refactor-using-optim
 
@@ -186,8 +185,7 @@ def get_model(
     :param initial_forget_bias: Value of the initial forget gate bias
     :param dropout: Dropout probability, from 0 to 1 (0 = don't use dropout)
     :param concat_static: If True, uses standard LSTM. Otherwise, uses EA-LSTM
-    :param learning_rate: Learning rate for optimizer
-    :returns: Tuple of model and optimizer
+    :returns: LSTM torch model
 
     """
     if torch.cuda.is_available():
@@ -206,8 +204,7 @@ def get_model(
         concat_static=concat_static
     ).to(device)
 
-    optimizer = Adam(model.parameters(), lr=learning_rate)
-    return model, optimizer
+    return model
 
 
 def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
@@ -365,15 +362,18 @@ def main(npz_filepath, weights_file, config):
     n_dynamic = len(config['dynamic_features_use'])
     n_static = len(config['static_features_use'])
 
-    # Create model and optimizer
-    model, optimizer = get_model(n_depths,
-                                 n_dynamic,
-                                 n_static,
-                                 config['hidden_size'],
-                                 config['initial_forget_bias'],
-                                 config['dropout'],
-                                 config['concat_static'],
-                                 config['learning_rate'])
+    # Create model
+    model = get_model(n_depths,
+                      n_dynamic,
+                      n_static,
+                      config['hidden_size'],
+                      config['initial_forget_bias'],
+                      config['dropout'],
+                      config['concat_static'])
+
+    # Create optimizer
+    optimizer = Adam(model.parameters(), lr=config['learning_rate'])
+
     # Get loss function
     # Equivalent to loss_func = nn.MSELoss()
     criterion_class = getattr(nn, config['loss_criterion'])

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -1,0 +1,69 @@
+import os
+import torch
+import torch.nn as nn
+from torch.utils.data import Dataset, DataLoader
+from torch.optim import Adam
+
+import numpy as np
+import sys
+sys.path.insert(1, '3_model/src')
+from models import Model
+
+
+class SequenceDataset(Dataset):
+    """
+    Custom Dataset class for sequences that include dynamic and static inputs,
+    and multiple outputs
+
+    __len__ returns the number of sequences
+    
+    __getitem__ returns dynamic input features, static input features, and
+    temperature observations at all depths for one sequence
+
+    Example:
+
+    >>> npz = np.load("2_process/out/mntoha/train.npz")
+    >>> n_dynamic = len(npz['dynamic_features_all'])
+    >>> n_static = len(npz['static_features_all'])
+    >>> n_depths = len(npz['depths'])
+    >>> data = torch.from_numpy(npz['data'])
+    >>> dataset = SequenceDataset(data, n_depths, n_dynamic, n_static)                            
+    >>> # number of sequences
+    >>> len(dataset)
+    19069
+    >>> # dynamic features, static features, and temperatures at depths 
+    >>> # for first sequence
+    >>> for e in dataset[0]:
+    >>>     print(e.shape)
+    >>> 
+    torch.Size([400, 9])
+    torch.Size([400, 4])
+    torch.Size([400, 49])
+
+    """
+    def __init__(self, sequences, n_outputs, n_dynamic, n_static):
+        """
+        :param sequences: An array of sequences with shape (# sequences, sequence_length, # depths + # input features)
+        :param n_outputs: Number of outputs (# depths)
+        :param n_dynamic: Number of dynamic input features
+        :param n_static: Number of static input features
+
+        """
+        # The number of sequences is the size of the first dimension
+        self.len = sequences.shape[0]
+        self.n_outputs = n_outputs
+        self.n_dynamic = n_dynamic
+        self.n_static = n_static
+        self.sequences = sequences
+
+    def __len__(self):
+        return self.len
+
+    def __getitem__(self, idx):
+        # sequence is organized as temperatures at multiple depths, then dynamic features, then static features
+        temperatures = self.sequences[idx, :, :self.n_outputs]
+        dynamic_features = self.sequences[idx, :, self.n_outputs:self.n_outputs + self.n_dynamic]
+        static_features = self.sequences[idx, :, -self.n_static:]
+        return dynamic_features, static_features, temperatures
+
+

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -86,6 +86,26 @@ def split(dataset, fraction, seed):
     return subset_1, subset_2
 
 
+def get_data_loaders(train_ds, valid_ds, batch_size):
+    """
+    Get data loaders for both the train dataset and the validate dataset
+
+    Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data
+
+    :param train_ds: Dataset for training data
+    :param valid_ds: Dataset for validation data
+    :param batch_size: Number of elements in each training batch
+    :returns: Tuple of training data loader and validation data loader
+
+    """
+    return (
+        DataLoader(train_ds, batch_size=batch_size, shuffle=True),
+        # The validate set is not used for training with backprop, so we can
+        # afford its batch size to be larger and it doesn't need to be shuffled
+        DataLoader(valid_ds, batch_size=batch_size * 2),
+    )
+
+
 def get_dataloader(npz_filepath,
                    dynamic_features_use,
                    static_features_use,

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -235,6 +235,10 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
     pred, h, c = model(x_d, x_s[:, 0, :])
     # Only compute loss where y is finite
     loss_idx = torch.isfinite(y)
+    # There should be at least one finite value in y
+    if not loss_idx.any():
+        raise ValueError('All temperature labels in this batch are not finite'
+                         ' (NaN, infinity, or negative infinity)')
     loss = loss_func(pred[loss_idx], y[loss_idx])
 
     if opt is not None:

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -162,3 +162,50 @@ def get_data(npz_filepath,
     train_subset, valid_subset = split(dataset, 1-valid_frac, seed)
     return get_data_loaders(train_subset, valid_subset, batch_size)
 
+
+def get_model(
+    n_depths,
+    n_dynamic,
+    n_static,
+    hidden_size,
+    initial_forget_bias,
+    dropout,
+    concat_static,
+    learning_rate
+):
+    """
+    Return LSTM model and optimizer
+
+    Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#refactor-using-optim
+
+    :param n_depths: Number of depths at which to predict temperatures (number
+        of outputs at each time step)
+    :param n_dynamic: Number of dynamic input features
+    :param n_static: Number of static input features
+    :param hidden_size: Number of elements in hidden state and cell state
+    :param initial_forget_bias: Value of the initial forget gate bias
+    :param dropout: Dropout probability, from 0 to 1
+    :param concat_static: If True, uses standard LSTM. Otherwise, uses EA-LSTM
+    :param learning_rate: Learning rate for optimizer
+    :returns: Tuple of model and optimizer
+
+    """
+    if torch.cuda.is_available():
+        device = "cuda" 
+    else:
+        device = "cpu"
+    print(f"Using {device} device")
+
+    model = Model(
+        input_size_dyn=n_dynamic,
+        input_size_stat=n_static,
+        hidden_size=hidden_size,
+        output_size=n_depths,
+        initial_forget_bias=initial_forget_bias,
+        dropout=dropout,
+        concat_static=concat_static
+    ).to(device)
+
+    optimizer = Adam(model.parameters(), lr=learning_rate)
+    return model, optimizer
+

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -89,7 +89,7 @@ def split(dataset, fraction, seed):
 def get_data_loaders(train_ds, valid_ds, batch_size):
     """
     Get data loaders for both the train dataset and the validate dataset
-
+    
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data
 
     :param train_ds: Dataset for training data
@@ -115,7 +115,7 @@ def get_data(npz_filepath,
              seed):
     """
     Get train and validate dataloaders from npz file
-
+    
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data
 
     :param npz_filepath: Name and path to .npz data file
@@ -175,7 +175,7 @@ def get_model(
 ):
     """
     Return LSTM model and optimizer
-
+    
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#refactor-using-optim
 
     :param n_depths: Number of depths at which to predict temperatures (number
@@ -214,9 +214,9 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
     """
     Evaluate loss for one batch of inputs and outputs, and optionally update model
     parameters by backpropagation
-
+    
     Non-finite (e.g. NaN) values in y are ignored.
-
+    
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data
 
     :param model: PyTorch model inheriting nn.Module()
@@ -250,7 +250,7 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
 def fit(epochs, model, loss_func, opt, train_dl, valid_dl):
     """
     Train the model, and compute training and validation losses for each epoch
-
+    
     Patterned after https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data
 
     :param epochs: Maximum number of training epochs
@@ -294,15 +294,17 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl):
         valid_losses.append(val_loss)
 
 
-def save_no_overwrite(model, filepath):
+def save_weights(model, filepath, overwrite=True):
     """
-    Save torch model without overwriting an existing file
+    Save weights of a torch model
     
-    Append a unique number to the end of the filename to avoid overwriting any
-    existing files.
+    Optionally, append a unique number to the end of the filename to avoid
+    overwriting any existing files.
 
     :param model: PyTorch model to be saved
     :param filepath: Path and filename to save to
+    :param overwrite:  (Default value = True) If True, overwrite existing file
+        if necessary
 
     """
     # Create new directory if needed
@@ -310,18 +312,20 @@ def save_no_overwrite(model, filepath):
     if not os.path.exists(directory):
         os.makedirs(directory)
 
-    root, extension = os.path.splitext(filepath)
-    suffix = 0
-    while os.path.exists(filepath):
-        suffix += 1
-        filepath = f'{root}_{suffix}{extension}'
+    if not overwrite:
+        # Append unique suffix to filename
+        root, extension = os.path.splitext(filepath)
+        suffix = 0
+        while os.path.exists(filepath):
+            suffix += 1
+            filepath = f'{root}_{suffix}{extension}'
     torch.save(model.state_dict(), filepath)
 
 
 def main(npz_filepath, weights_file, config):
     """
     Train a model and save the trained weights
-
+    
     Load training and validation data from a .npz file. Use the settings
     specified in the config dictionary. Train the model, and save its weights.
 
@@ -378,7 +382,7 @@ def main(npz_filepath, weights_file, config):
     # Training loop
     fit(config['max_epochs'], model, loss_func, optimizer, train_data_loader, valid_data_loader)
     print('Finished Training')
-    save_no_overwrite(model, weights_file)
+    save_weights(model, weights_file, overwrite=True)
 
 
 

--- a/3_train/train_config.yaml
+++ b/3_train/train_config.yaml
@@ -1,0 +1,29 @@
+# features to use
+dynamic_features_use: ['ShortWave', 'LongWave', 'AirTemp', 'RelHum',
+                        'WindSpeed', 'Rain', 'Snow']
+static_features_use: ['area', 'centroid_lon', 'centroid_lat', 'elevation']
+depths_use: [0.,  0.5,  1.,  1.5,  2.,  2.5,  3.,  3.5,  4.,  4.5,  5., 5.5,
+              6., 6.5, 7.,  7.5,  8.,  8.5,  9.,  9.5, 10., 11., 12., 13., 14.,
+              15., 16., 17., 18., 19., 20., 22., 24., 26., 28., 30., 32., 34.,
+              36., 38., 40., 45., 50., 55., 60., 65., 70., 75., 80.]
+
+# model architecture
+hidden_size: 20
+concat_static: False # False for EA-LSTM, True for CS-LSTM
+
+# validation set
+valid_frac: 0.20
+k_folds: 5
+
+# training
+batch_size: 64
+initial_forget_bias: 5 # value of the initial forget bias gate
+dropout: 0.0
+begin_loss_ind: 0 #index in sequence where we begin to calculate error or predict
+learning_rate: 0.005
+loss_criterion: 'MSELoss'
+early_stopping: True
+max_epochs: 3
+
+seed: 12345
+

--- a/Snakefile
+++ b/Snakefile
@@ -6,5 +6,5 @@ include: "3_train.smk"
 rule all:
     input:
         pull_date = "1_fetch/in/pull_date.txt",
-        weights_filepath = "3_train/out/mntoha/lstm.pt"
+        weights_filepath = "3_train/out/mntoha/0/lstm.pt"
 

--- a/Snakefile
+++ b/Snakefile
@@ -1,9 +1,10 @@
 include: "1_fetch.smk"
 include: "2_process.smk"
+include: "3_train.smk"
 
 
 rule all:
     input:
-        "1_fetch/in/pull_date.txt",
-        "2_process/out/mntoha_sequences/mntoha_sequences_summary.csv"
+        pull_date = "1_fetch/in/pull_date.txt",
+        weights_file = "3_train/out/mntoha/lstm.pt"
 

--- a/Snakefile
+++ b/Snakefile
@@ -6,5 +6,5 @@ include: "3_train.smk"
 rule all:
     input:
         pull_date = "1_fetch/in/pull_date.txt",
-        weights_file = "3_train/out/mntoha/lstm.pt"
+        weights_filepath = "3_train/out/mntoha/lstm.pt"
 


### PR DESCRIPTION
This PR allows an LSTM or an EA-LSTM to be trained to predict lake temperatures at multiple depths using MNTOHA data. Closes #20.

The structure of the functions is patterned after [this tutorial](https://pytorch.org/tutorials/beginner/nn_tutorial.html#create-fit-and-get-data).

To execute the full pipeline and train the model for 3 epochs, run
```
conda update -n base conda
conda env create -f environment.yaml
conda activate ltls
snakemake --cores all 3_train/out/mntoha/0/lstm.pt
```
NOTE: This will require about half an hour and 7 GB of disk space. The pipeline downloads MNTOHA data from ScienceBase, forms training data, and trains an EA-LSTM for 3 epochs as a test.

DONE:
- Save losses at every epoch
- Average loss weighted by the number of non-NaN observations
- Save settings and other metadata alongside model weights

TODO in later PRs, in order of importance (time allowing):
- Implement early stopping
- Allow pre-trained model to be used
- Split validation data apart by lake, not sequence
- Allow different weight initializations
- Allow different optimizers
- Implement cross-validation
- Save space by saving only one copy of static attributes to training data .npz