### PR TITLE
Log settings and other metadata after training

### DIFF
--- a/2_process.smk
+++ b/2_process.smk
@@ -24,7 +24,7 @@ def trigger_unzip_archive(file_category, archive_name):
 
 
 def get_obs_file(file_category, archive_name, obs_file_name):
-    '''
+    """
     Return temperature observations filepath.
 
     Depend on unzip_archive checkpoint to ensure that
@@ -37,7 +37,7 @@ def get_obs_file(file_category, archive_name, obs_file_name):
     :param obs_file_name: name of unzipped observation file
     :returns: Path of temperature observations csv
 
-    '''
+    """
     # Trigger checkpoint to unzip observation file
     obs_file_directory = trigger_unzip_archive(file_category, archive_name)
     return os.path.join(obs_file_directory, obs_file_name)

--- a/3_train.smk
+++ b/3_train.smk
@@ -1,10 +1,27 @@
 
 configfile: "3_train/train_config.yaml"
 
+# Save config files to output directory
+rule save_config:
+    input:
+        process_config = "2_process/process_config.yaml",
+        train_config = "3_train/train_config.yaml"
+    output:
+        process_config = "3_train/out/{data_source}/{run_id}/process_config.yaml",
+        train_config = "3_train/out/{data_source}/{run_id}/train_config.yaml"
+    shell:
+        """
+        mkdir -p 3_train/out/{wildcards.data_source}/{wildcards.run_id}
+        cp {input.process_config} {output.process_config}
+        cp {input.train_config} {output.train_config}
+        """
+
 # Train model
 rule train_model:
     input:
-        npz_filepath = "2_process/out/{data_source}/train.npz"
+        npz_filepath = "2_process/out/{data_source}/train.npz",
+        process_config = "3_train/out/{data_source}/{run_id}/process_config.yaml",
+        train_config = "3_train/out/{data_source}/{run_id}/train_config.yaml"
     output:
         weights_filepath = "3_train/out/{data_source}/{run_id}/lstm.pt",
         metadata_filepath = "3_train/out/{data_source}/{run_id}/metadata.npz"

--- a/3_train.smk
+++ b/3_train.smk
@@ -22,7 +22,8 @@ rule save_config:
 rule train_model:
     input:
         npz_filepath = "2_process/out/{data_source}/train.npz",
-        # Include configs as inputs in order to save them to the output folder
+        # Include configs as inputs in order to trigger save_config rule,
+        # and save configs to the output folder
         process_config = "3_train/out/{data_source}/{run_id}/process_config.yaml",
         train_config = "3_train/out/{data_source}/{run_id}/train_config.yaml"
     output:

--- a/3_train.smk
+++ b/3_train.smk
@@ -23,11 +23,14 @@ rule train_model:
         process_config = "3_train/out/{data_source}/{run_id}/process_config.yaml",
         train_config = "3_train/out/{data_source}/{run_id}/train_config.yaml"
     output:
-        weights_filepath = "3_train/out/{data_source}/{run_id}/lstm.pt",
-        metadata_filepath = "3_train/out/{data_source}/{run_id}/metadata.npz"
+        weights_filepath = "3_train/out/{data_source}/{run_id}/{model_id}_weights.pt",
+        metadata_filepath = "3_train/out/{data_source}/{run_id}/{model_id}_metadata.npz"
     params:
         config = config,
-        run_id = lambda wildcards: wildcards.run_id
+        run_id = lambda wildcards: wildcards.run_id,
+        model_id = lambda wildcards: wildcards.model_id
+    threads:
+        16
     script:
         "3_train/src/train.py"
 

--- a/3_train.smk
+++ b/3_train.smk
@@ -31,3 +31,11 @@ rule train_model:
     script:
         "3_train/src/train.py"
 
+# Summarize all training runs so far
+rule summarize_training_runs:
+    # No inputs because we don't want this rule to trigger the train_model rule
+    output: 
+        summary_filepath = "3_train/out/{data_source}/summary.csv"
+    script:
+        "3_train/src/summarize.py"
+

--- a/3_train.smk
+++ b/3_train.smk
@@ -6,10 +6,11 @@ rule train_model:
     input:
         npz_filepath = "2_process/out/{data_source}/train.npz"
     output:
-        weights_filepath = "3_train/out/{data_source}/{run}/lstm.pt",
-        metadata_filepath = "3_train/out/{data_source}/{run}/metadata.npz"
+        weights_filepath = "3_train/out/{data_source}/{run_id}/lstm.pt",
+        metadata_filepath = "3_train/out/{data_source}/{run_id}/metadata.npz"
     params:
-        config = config
+        config = config,
+        run_id = lambda wildcards: wildcards.run_id
     script:
         "3_train/src/train.py"
 

--- a/3_train/src/summarize.py
+++ b/3_train/src/summarize.py
@@ -4,23 +4,46 @@ import numpy as np
 import pandas as pd
 
 # Don't write these out to the summary file (they're long lists)
-files_to_exclude = [
+FILES_TO_EXCLUDE = [
     'train_data_means',
     'train_data_stds',
     'train_losses',
     'valid_losses'
 ]
 
-def read_npz_as_dataframe(filename):
-    npz = np.load(filename)
+def read_npz_as_dataframe(npz_name):
+    """
+    Read a numpy npz and convert to a pandas DataFrame.
+
+    Exclude specific files that are inside the npz from the DataFrame because
+    they are long lists that don't need to be saved to a summary file.
+
+    :param npz_name: Name of npz to read
+    :returns: Pandas DataFrame containing contents of npz, with the names of
+        the files in the npz as column names
+
+    """
+    npz = np.load(npz_name)
     # Make every item in the dict a one-element list so that pandas can read it in easily
-    metadata_dict = {file: [npz[file]] for file in npz.files if not file in files_to_exclude}
+    metadata_dict = {file: [npz[file]] for file in npz.files if not file in FILES_TO_EXCLUDE}
     df = pd.DataFrame.from_dict(metadata_dict, orient='columns')
     return df
 
 
 def main(summary_filepath):
+    """
+    Summarize all trained models in all subdirectories of a given root directory.
 
+    Read in all .npz files in the subdirectories of the root and assume that
+    all .npz files are metadata files saved to accompany trained models.
+    Extract information to summarize from those .npz files, and save it to a
+    csv. Use the combination of the run_id and the model_id to create a unique
+    identifier for every trained model, and save that in the first column of
+    the summary csv. 
+
+    :param summary_filepath: File path of the summarizing csv to create
+
+    """
     metadata_file_pattern = '*.npz'
     # Search the directory that will contain the summary file 
     # for all metadata npz files, recursively

--- a/3_train/src/summarize.py
+++ b/3_train/src/summarize.py
@@ -1,0 +1,41 @@
+import os
+import glob
+import numpy as np
+import pandas as pd
+
+# Don't write these out to the summary file (they're long lists)
+files_to_exclude = [
+    'train_data_means',
+    'train_data_stds',
+    'train_losses',
+    'valid_losses'
+]
+
+def read_npz_as_dataframe(filename):
+    npz = np.load(filename)
+    # Make every item in the dict a one-element list so that pandas can read it in easily
+    metadata_dict = {file: [npz[file]] for file in npz.files if not file in files_to_exclude}
+    df = pd.DataFrame.from_dict(metadata_dict, orient='columns')
+    return df
+
+
+def main(summary_filepath):
+
+    metadata_file_pattern = '*.npz'
+    # Search the directory that will contain the summary file 
+    # for all metadata npz files, recursively
+    summary_dir = os.path.dirname(summary_filepath)
+    glob_str = summary_dir + os.sep + '**' + os.sep + metadata_file_pattern
+    metadata_files = glob.glob(glob_str, recursive=True)
+
+    # Read all metadata npzs into a list of DataFrames
+    dfs = [read_npz_as_dataframe(fn) for fn in metadata_files]
+    # Concatenate list of DataFrames into one DataFrame
+    summary_df = pd.concat(dfs, sort=False)
+    # run_id should be a unique identifier
+    summary_df.set_index('run_id', inplace=True)
+    summary_df.to_csv(summary_filepath)
+
+if __name__ == '__main__':
+    main(snakemake.output.summary_filepath)
+

--- a/3_train/src/summarize.py
+++ b/3_train/src/summarize.py
@@ -14,7 +14,7 @@ FILES_TO_EXCLUDE = [
 def read_npz_as_dataframe(npz_name):
     """
     Read a numpy npz and convert to a pandas DataFrame.
-
+    
     Exclude specific files that are inside the npz from the DataFrame because
     they are long lists that don't need to be saved to a summary file.
 
@@ -33,13 +33,13 @@ def read_npz_as_dataframe(npz_name):
 def main(summary_filepath):
     """
     Summarize all trained models in all subdirectories of a given root directory.
-
+    
     Read in all .npz files in the subdirectories of the root and assume that
     all .npz files are metadata files saved to accompany trained models.
     Extract information to summarize from those .npz files, and save it to a
     csv. Use the combination of the run_id and the model_id to create a unique
     identifier for every trained model, and save that in the first column of
-    the summary csv. 
+    the summary csv.
 
     :param summary_filepath: File path of the summarizing csv to create
 

--- a/3_train/src/summarize.py
+++ b/3_train/src/summarize.py
@@ -32,8 +32,9 @@ def main(summary_filepath):
     dfs = [read_npz_as_dataframe(fn) for fn in metadata_files]
     # Concatenate list of DataFrames into one DataFrame
     summary_df = pd.concat(dfs, sort=False)
-    # run_id should be a unique identifier
-    summary_df.set_index('run_id', inplace=True)
+    # Use combination of run_id and model_id as a unique index
+    summary_df['full_id'] = summary_df['run_id'].astype(str) + '.' + summary_df['model_id'].astype(str)
+    summary_df.set_index('full_id', inplace=True)
     summary_df.to_csv(summary_filepath)
 
 if __name__ == '__main__':

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -419,7 +419,7 @@ def get_git_status():
     return subprocess.check_output(['git', 'status']).decode('ascii').strip()
 
 
-def main(npz_filepath, weights_filepath, metadata_filepath, run_id, config):
+def main(npz_filepath, weights_filepath, metadata_filepath, run_id, model_id, config):
     """
     Train a model and save the trained weights
     
@@ -497,6 +497,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, config):
     # Save model weights
     save_weights(model, weights_filepath, overwrite=True)
     # Save model settings and training metrics
+    config['model_id'] = model_id
     config['train_start_time'] = train_start_time
     config['train_end_time'] = train_end_time
     config['train_losses'] = train_losses
@@ -512,5 +513,6 @@ if __name__ == '__main__':
          snakemake.output.weights_filepath,
          snakemake.output.metadata_filepath,
          snakemake.params.run_id,
+         snakemake.params.model_id,
          snakemake.params.config)
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -268,6 +268,8 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, verbose=False):
     :param opt: Optimizer to use to update model parameters
     :param train_dl: PyTorch DataLoader with training data
     :param valid_dl: PyTorch DataLoader with validation data
+    :param verbose: Print more messages during execution 
+        (Default value = False)
     :returns: Tuple of arrays of training and validation losses for each epoch
 
     """
@@ -328,8 +330,9 @@ def save_weights(model, filepath, overwrite=True):
 
     :param model: PyTorch model to be saved
     :param filepath: Path and filename to save to
-    :param overwrite:  (Default value = True) If True, overwrite existing file
-        if necessary
+    :param overwrite: If True, overwrite existing file if necessary. If False,
+        append a unique suffix to the filename before saving.
+        (Default value = True)
 
     """
     # Create new directory if needed
@@ -360,8 +363,9 @@ def save_metadata(config, npz_filepath, save_filepath, overwrite=True):
     :param config: Dictionary of configuration settings and training results to save
     :param npz_filepath: Name and path to .npz data file containing training data
     :param save_filepath: Path and filename to save to
-    :param overwrite:  (Default value = True) If True, overwrite existing file
-        if necessary
+    :param overwrite: If True, overwrite existing file if necessary. If False,
+        append a unique suffix to the filename before saving.
+        (Default value = True)
 
     """
     # Create new directory if needed

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -414,7 +414,7 @@ def get_git_status():
     return subprocess.check_output(['git', 'status']).decode('ascii').strip()
 
 
-def main(npz_filepath, weights_filepath, metadata_filepath, config):
+def main(npz_filepath, weights_filepath, metadata_filepath, run_id, config):
     """
     Train a model and save the trained weights
     
@@ -424,6 +424,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, config):
     :param npz_filepath: Name and path to .npz data file
     :param weights_filepath: Path and filename to save weights to
     :param metadata_filepath: Path and filename to save metadata to
+    :param run_id: ID of the current training run (experiment)
     :param config: Dictionary of configuration settings, including:
         max_epochs            integer, Maximum number of epochs to train for
         loss_criterion        string, Name of class in torch.nn to use for loss
@@ -440,6 +441,10 @@ def main(npz_filepath, weights_filepath, metadata_filepath, config):
         batch_size            integer, Number of examples per training batch
 
     """
+    # Check that run_id in config matches output path
+    if not (run_id == config['run_id']):
+        raise ValueError(f"The values of 'run_id' do not match. 'run_id' in process_config.yaml is {config['run_id']}, but 'run_id' in the output filepath is {run_id}.")
+
     # Set seed to encourage reprodicibility
     torch.manual_seed(config['seed'])
 
@@ -496,5 +501,6 @@ if __name__ == '__main__':
     main(snakemake.input.npz_filepath,
          snakemake.output.weights_filepath,
          snakemake.output.metadata_filepath,
+         snakemake.params.run_id,
          snakemake.params.config)
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -403,6 +403,17 @@ def get_git_hash():
     return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
 
 
+def get_git_status():
+    """
+    Get the output of the `git status` command
+
+    :returns: String of output of `git status`
+
+    """
+    # status = str(subprocess.Popen(['git status'], cwd = None if code_dir=="" else code_dir,shell=True,stdout=subprocess.PIPE).communicate()[0]).split("\\n")
+    return subprocess.check_output(['git', 'status']).decode('ascii').strip()
+
+
 def main(npz_filepath, weights_filepath, metadata_filepath, config):
     """
     Train a model and save the trained weights
@@ -477,6 +488,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, config):
     config['train_losses'] = train_losses
     config['valid_losses'] = valid_losses
     config['git_hash'] = get_git_hash()
+    config['git_status'] = get_git_status()
     save_metadata(config, npz_filepath, metadata_filepath, overwrite=True)
 
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -268,7 +268,7 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, verbose=False):
     :param opt: Optimizer to use to update model parameters
     :param train_dl: PyTorch DataLoader with training data
     :param valid_dl: PyTorch DataLoader with validation data
-    :param verbose: Print more messages during execution 
+    :param verbose: Print more messages during execution
         (Default value = False)
     :returns: Tuple of arrays of training and validation losses for each epoch
 
@@ -496,6 +496,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, config):
     # Save model settings and training metrics
     config['train_losses'] = train_losses
     config['valid_losses'] = valid_losses
+    config['n_epochs_trained'] = len(train_losses)
     config['git_hash'] = get_git_hash()
     config['git_status'] = get_git_status()
     save_metadata(config, npz_filepath, metadata_filepath, overwrite=True)

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -429,8 +429,12 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, model_id, co
     :param npz_filepath: Name and path to .npz data file
     :param weights_filepath: Path and filename to save weights to
     :param metadata_filepath: Path and filename to save metadata to
-    :param run_id: ID of the current training run (experiment)
+    :param run_id: ID of the current training run (experiment). Value must
+        match the run_id as defined in the config dictionary.
+    :param model_id: ID of the model to train within the current training run
     :param config: Dictionary of configuration settings, including:
+        run_id                string, ID of current run (experiment)
+        run_description       string, plain language description of current run
         max_epochs            integer, Maximum number of epochs to train for
         loss_criterion        string, Name of class in torch.nn to use for loss
         learning_rate         float, Learning rate of optimizer

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -1,6 +1,7 @@
 # Train an LSTM or EA-LSTM and save the results with metadata
 
 import os
+import subprocess
 import numpy as np
 import torch
 import torch.nn as nn
@@ -390,6 +391,18 @@ def save_metadata(config, npz_filepath, save_filepath, overwrite=True):
     np.savez(save_filepath, **metadata)
 
 
+def get_git_hash():
+    """
+    Get the hash of the current git revision
+
+    From https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script
+
+    :returns: String of current git revision's hash
+
+    """
+    return subprocess.check_output(['git', 'rev-parse', 'HEAD']).decode('ascii').strip()
+
+
 def main(npz_filepath, weights_filepath, metadata_filepath, config):
     """
     Train a model and save the trained weights
@@ -463,6 +476,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, config):
     # Save model settings and training metrics
     config['train_losses'] = train_losses
     config['valid_losses'] = valid_losses
+    config['git_hash'] = get_git_hash()
     save_metadata(config, npz_filepath, metadata_filepath, overwrite=True)
 
 

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -2,6 +2,7 @@
 
 import os
 import subprocess
+from datetime import datetime
 import numpy as np
 import torch
 import torch.nn as nn
@@ -488,12 +489,16 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, config):
     loss_func = criterion_class()
 
     # Training loop
+    train_start_time = str(datetime.now())
     train_losses, valid_losses = fit(config['max_epochs'], model, loss_func, optimizer, train_data_loader, valid_data_loader)
+    train_end_time = str(datetime.now())
     print('Finished Training')
 
     # Save model weights
     save_weights(model, weights_filepath, overwrite=True)
     # Save model settings and training metrics
+    config['train_start_time'] = train_start_time
+    config['train_end_time'] = train_end_time
     config['train_losses'] = train_losses
     config['valid_losses'] = valid_losses
     config['n_epochs_trained'] = len(train_losses)

--- a/3_train/train_config.yaml
+++ b/3_train/train_config.yaml
@@ -1,4 +1,4 @@
-# ID of this run
+# This run
 run_id: '1'
 run_description: 'Initial run'
 

--- a/3_train/train_config.yaml
+++ b/3_train/train_config.yaml
@@ -1,3 +1,7 @@
+# ID of this run
+run_id: '1'
+run_description: 'Initial run'
+
 # features to use
 dynamic_features_use: ['ShortWave', 'LongWave', 'AirTemp', 'RelHum',
                         'WindSpeed', 'Rain', 'Snow']

--- a/Snakefile
+++ b/Snakefile
@@ -6,5 +6,5 @@ include: "3_train.smk"
 rule all:
     input:
         pull_date = "1_fetch/in/pull_date.txt",
-        weights_filepath = "3_train/out/mntoha/0/lstm.pt"
+        summary_filepath = "3_train/out/mntoha/summary.csv"
 


### PR DESCRIPTION
Save configuration settings, details about training, and preliminary performance metrics after training a model. Summarize all of that metadata for all trained models in one csv file. Closes #18.

This PR provides a way to summarize all the trained models so far in a csv. 
`snakemake -c1 3_train/out/mntoha/summary.csv`
There is also an option to summarize all the models in a single run only. This is useful when a run is a hyperparameter search that produced many models.
`snakemake -c1 3_train/out/mntoha/tune_hidden_size/summary.csv`
NOTE: the above commands won't work if there are no npz files associated with trained models to summarize. If it would help, I can provide a series of commands that would quickly train a couple of models and then summarize them.

As an example, the structure of `3_train/out` might look like this:
```
3_train/
| out/
| | mntoha/
| | | dynamic_inputs_1/
| | | | a_metadata.npz
| | | | a_weights.pt
| | | | process_config.yaml
| | | | train_config.yaml
| | | dynamic_inputs_2/
| | | | a_metadata.npz
| | | | a_weights.pt
| | | | process_config.yaml
| | | | train_config.yaml
| | | tune_hidden_size_and_dropout/
| | | | hidden_size-50_dropout-0.0_metadata.npz
| | | | hidden_size-50_dropout-0.0_weights.pt
| | | | hidden_size-100_dropout-0.0_metadata.npz
| | | | hidden_size-100_dropout-0.0_weights.pt
| | | | hidden_size-50_dropout-0.2_metadata.npz
| | | | hidden_size-50_dropout-0.2_weights.pt
| | | | hidden_size-100_dropout-0.2_metadata.npz
| | | | hidden_size-100_dropout-0.2_weights.pt
| | | | process_config.yaml
| | | | train_config.yaml
| | | summary.csv
| | full_footprint
| | | dynamic_inputs_1/
| | | | a_metadata.npz
| | | | a_weights.pt
| | | | process_config.yaml
| | | | train_config.yaml
| | | summary.csv
```
Here there are two data sources: `mntoha` and `full_footprint`. `mntoha` has three runs with `run_id` values `dynamic_inputs_1`, `dynamic_inputs_2`, and `tune_hidden_size_and_dropout`. The first two runs have only one `model_id`: `a`. The third run did a grid search: two hyperparameters, searching over two values apiece. The third run has multiple models with different `model_id`s corresponding to the values tested during the grid search, like `hidden_size-50_dropout-0.0`, for example.

The PR also adds to the information that is saved after training. 

## Metadata saved:

- full_id (combination of run_id and model_id)
- sequence_length
- sequence_offset
- spinup_time
- depths
- train_frac
- test_frac
- depths_all (all discrete depths used during processing to interpolate temperature observations)
- dynamic_features_all
- static_features_all
- seed
- run_id (set in train_config.yaml and via the snakemake command; these two must agree)
- run_description
- overwrite (boolean of whether or not to overwrite existing results. Right now, ineffective)
- dynamic_features_use
- static_features_use
- depths_use (all discrete depths used during training)
- hidden_size
- concat_static (boolean of whether to use an EA-LSTM or regular LSTM)
- valid_frac
- k_folds
- batch_size
- initial_forget_bias
- dropout
- begin_loss_ind
- learning_rate
- loss_criterion
- early_stopping
- max_epochs
- model_id (set via the snakemake command. Going forward, this can be used to distinguish among models during a grid search)
- train_start_time
- train_end_time
- n_epochs_trained
- git_hash
- git_status (full message returns by running `git status` - useful to see if the repo was clean or not when the model was trained)

The metadata includes all the info from `process_config.yaml` and `train_config.yaml`. Those yaml files also get saved directly to the run folder as well. There's some redundancy there, but I see no harm in it.

## Note about pipeline structure

I decoupled the rule to summarize, `summarize_trained_models`, from the rest of the pipeline. My concern that running that rule might accidentally trigger re-training a model, so I gave that rule no inputs. Hope that makes sense!

# How to review this PR

After today's sprint meeting, I'm experimenting with this section! Let's see if it helps...

## Level of review requested

Since we want to get some preliminary models trained soon, the main things I'd like reviewed are:

1. Are there any obvious reasons the code won't work as expected?
2. Are there any "gotchas" lying in wait?
3. Is there any additional metadata that should be saved after training?
4. Are there changes that will make things significantly easier for us going forward?

I'm happy to clarify any questions about how the code should work.

If there are substantial edits that would be good-to-have but wouldn't be necessary at this point, feel free to suggest them and I'll spin them off into a new issue!

## Where in the code to focus

Basically, all new/edited snakemake or python code is fair game. There are some edits to docstrings that don't warrant close attention.