### PR TITLE
Tallgrass GPU bug fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -162,13 +162,13 @@ dmypy.json
 .Rproj.user
 
 # Specific files and directories to exclude
-1_fetch/tmp
-1_fetch/out
-2_process/log
-2_process/tmp
-2_process/out
-3_train/out
-log
+/1_fetch/tmp/
+/1_fetch/out/
+/2_process/log/
+/2_process/tmp/
+/2_process/out/
+/3_train/out/
+/log/
 
 # Specific files to include
 !/notebooks/Explore_MNTOHA_temperature_observations.html

--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,8 @@
 *.patch
 *.pdf
 *.svg
+*.swp
+*.swo
 
 # Byte-compiled / optimized / DLL files
 __pycache__/
@@ -166,6 +168,7 @@ dmypy.json
 2_process/tmp
 2_process/out
 3_train/out
+log
 
 # Specific files to include
 !/notebooks/Explore_MNTOHA_temperature_observations.html

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -281,11 +281,11 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, device, verbose=False
     def verbose_print(*args):
         # Only print if verbose is true
         if verbose:
-            print(*args)
+            print(*args, flush=True)
 
     train_losses = []
     valid_losses = []
-    print('Epoch: train loss, validate loss')
+    print('Epoch: train loss, validate loss', flush=True)
     # Training loop
     for epoch in range(epochs):
         model.train()
@@ -315,7 +315,7 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, device, verbose=False
                 verbose_print(batch_loss, batch_count)
                 valid_loss += batch_loss * batch_count/n_valid
 
-        print(f'{epoch}: {train_loss}, {valid_loss}')
+        print(f'{epoch}: {datetime.now()} {train_loss}, {valid_loss}', flush=True)
         train_losses.append(train_loss)
         valid_losses.append(valid_loss)
     return train_losses, valid_losses
@@ -478,11 +478,11 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, model_id, co
         device = "cuda" 
     else:
         device = "cpu"
-    print(f"Using {device} device")
+    print(f"Using {device} device", flush=True)
 
-    print(f"Number of threads set by user: {torch.get_num_threads()}")
-    print(f"Number of GPUs: {torch.cuda.device_count()}")
-    print(f"Number of CPUs: {os.cpu_count()}")
+    print(f"Number of threads set by user: {torch.get_num_threads()}", flush=True)
+    print(f"Number of GPUs: {torch.cuda.device_count()}", flush=True)
+    print(f"Number of CPUs: {os.cpu_count()}", flush=True)
 
     # Create model
     model = get_model(n_depths,
@@ -505,7 +505,7 @@ def main(npz_filepath, weights_filepath, metadata_filepath, run_id, model_id, co
     train_start_time = str(datetime.now())
     train_losses, valid_losses = fit(config['max_epochs'], model, loss_func, optimizer, train_data_loader, valid_data_loader, device)
     train_end_time = str(datetime.now())
-    print('Finished Training')
+    print('Finished Training', flush=True)
 
     # Save model weights
     save_weights(model, weights_filepath, overwrite=True)

--- a/environment.yaml
+++ b/environment.yaml
@@ -6,12 +6,15 @@ channels:
 dependencies: 
   - pip
   - pytorch = 1.10.1
-  - torchvision = 0.11.2
-  - torchaudio = 0.10.1
+  - torchvision
+  - torchaudio
+  - cudatoolkit = 11.3
   - snakemake
   - pandas 
   - numpy
   - matplotlib
+  - scipy
+  - git
   - jupyterlab
   - ipykernel
   - pip:

--- a/setup.sh
+++ b/setup.sh
@@ -1,4 +1,3 @@
 conda activate ltls
 module load analytics cuda11.3/toolkit/11.3.0 
 export LD_LIBRARY_PATH=/cm/shared/apps/nvidia/TensorRT-6.0.1.5/lib:/cm/shared/apps/nvidia/cudnn_8.0.5/lib64:$LD_LIBRARY_PATH
-# salloc -N 1 -n 1 -c 1 -p cpu -A watertemp -t 1-23:59:59

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,4 @@
+conda activate ltls
+module load analytics cuda11.3/toolkit/11.3.0 
+export LD_LIBRARY_PATH=/cm/shared/apps/nvidia/TensorRT-6.0.1.5/lib:/cm/shared/apps/nvidia/cudnn_8.0.5/lib64:$LD_LIBRARY_PATH
+# salloc -N 1 -n 1 -c 1 -p cpu -A watertemp -t 1-23:59:59

--- a/sn_cpu.slurm
+++ b/sn_cpu.slurm
@@ -3,7 +3,8 @@
 #SBATCH --account=watertemp
 #SBATCH --partition=cpu
 #SBATCH --job-name=snakemake
-#SBATCH --time=1-23:59:59
+#SBATCH --time=7:59:59
+#SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=16
 #SBATCH --output=log/sbatch_all_%a_%A.out
@@ -22,5 +23,5 @@ log_dir=log/${run_id}_${model_id}
 mkdir -p ${log_dir}
 # From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
 # Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
-snakemake --cluster "srun -A watertemp -t 1-23:59:59 -p cpu -N 1 -n 1 -c 16 --job-name=${run_id}_${model_id} -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+snakemake --cluster "srun -A watertemp -t 7:59:59 -p cpu -N 1 -n 1 -c 16 --job-name=${run_id}_${model_id} -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
 

--- a/sn_cpu.slurm
+++ b/sn_cpu.slurm
@@ -3,16 +3,16 @@
 #SBATCH --account=watertemp
 #SBATCH --partition=cpu
 #SBATCH --job-name=snakemake
-#SBATCH --time=7:59:59
+#SBATCH --time=1:59:59
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
-#SBATCH --cpus-per-task=16
+#SBATCH --cpus-per-task=1
 #SBATCH --output=log/sbatch_all_%a_%A.out
 #SBATCH --error=log/sbatch_all_%a_%A.out
 
 ## Initialize work environment
-# conda activate ltls
-# which python
+source ~/.bashrc
+conda activate ltls
 module load analytics cuda11.3/toolkit/11.3.0
 
 ## Run the main job
@@ -23,5 +23,5 @@ log_dir=log/${run_id}_${model_id}
 mkdir -p ${log_dir}
 # From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
 # Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
-snakemake --cluster "srun -A watertemp -t 7:59:59 -p cpu -N 1 -n 1 -c 16 --job-name=${run_id}_${model_id} -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+snakemake --cluster "sbatch -A watertemp -t 1:59:59 -p cpu -N 1 -n 1 -c 1 --job-name=${run_id}_${model_id} -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 8 --rerun-incomplete train_models 2>&1 | tee ${log_dir}/run.out
 

--- a/sn_cpu.slurm
+++ b/sn_cpu.slurm
@@ -1,0 +1,26 @@
+#!/bin/bash
+#
+#SBATCH --account=watertemp
+#SBATCH --partition=cpu
+#SBATCH --job-name=snakemake
+#SBATCH --time=1-23:59:59
+#SBATCH --ntasks=1
+#SBATCH --cpus-per-task=16
+#SBATCH --output=log/sbatch_all_%a_%A.out
+#SBATCH --error=log/sbatch_all_%a_%A.out
+
+## Initialize work environment
+# conda activate ltls
+# which python
+module load analytics cuda11.3/toolkit/11.3.0
+
+## Run the main job
+
+run_id=test1
+model_id=cpu_a
+log_dir=log/${run_id}_${model_id}
+mkdir -p ${log_dir}
+# From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
+# Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
+snakemake --cluster "srun -A watertemp -t 1-23:59:59 -p cpu -N 1 -n 1 -c 16 --job-name=${run_id}_${model_id} -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+

--- a/sn_gpu.slurm
+++ b/sn_gpu.slurm
@@ -3,9 +3,11 @@
 #SBATCH --account=watertemp
 #SBATCH --partition=gpu
 #SBATCH --job-name=snakemake
-#SBATCH --time=1-23:59:59
+#SBATCH --time=7:59:59
 #SBATCH --gres=gpu:1 # don't need the gpu type on tallgrass
+#SBATCH --nodes=1
 #SBATCH --ntasks=1
+#SBATCH --cpus-per-task=1
 #SBATCH --output=log/sbatch_all_%a_%A.out
 #SBATCH --error=log/sbatch_all_%a_%A.out
 
@@ -23,5 +25,5 @@ mkdir -p ${log_dir}
 # From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
 # Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
 # srun snakemake --cluster "sbatch -A watertemp -t 1-23:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" -p -k --cores all --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
-snakemake --cluster "srun -A watertemp -t 1-23:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+snakemake --cluster "srun -A watertemp -t 7:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
 

--- a/sn_gpu.slurm
+++ b/sn_gpu.slurm
@@ -1,0 +1,27 @@
+#!/bin/bash
+#
+#SBATCH --account=watertemp
+#SBATCH --partition=gpu
+#SBATCH --job-name=snakemake
+#SBATCH --time=1-23:59:59
+#SBATCH --gres=gpu:1 # don't need the gpu type on tallgrass
+#SBATCH --ntasks=1
+#SBATCH --output=log/sbatch_all_%a_%A.out
+#SBATCH --error=log/sbatch_all_%a_%A.out
+
+## Initialize work environment
+# conda activate ltls
+# which python
+module load analytics cuda11.3/toolkit/11.3.0
+
+## Run the main job
+
+run_id=initial1
+model_id=gpu_a
+log_dir=log/${run_id}_${model_id}
+mkdir -p ${log_dir}
+# From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
+# Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
+# srun snakemake --cluster "sbatch -A watertemp -t 1-23:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" -p -k --cores all --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+snakemake --cluster "srun -A watertemp -t 1-23:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
+

--- a/sn_gpu.slurm
+++ b/sn_gpu.slurm
@@ -1,10 +1,9 @@
 #!/bin/bash
 #
 #SBATCH --account=watertemp
-#SBATCH --partition=gpu
+#SBATCH --partition=cpu
 #SBATCH --job-name=snakemake
-#SBATCH --time=7:59:59
-#SBATCH --gres=gpu:1 # don't need the gpu type on tallgrass
+#SBATCH --time=1:59:59
 #SBATCH --nodes=1
 #SBATCH --ntasks=1
 #SBATCH --cpus-per-task=1
@@ -12,8 +11,8 @@
 #SBATCH --error=log/sbatch_all_%a_%A.out
 
 ## Initialize work environment
-# conda activate ltls
-# which python
+source ~/.bashrc
+conda activate ltls
 module load analytics cuda11.3/toolkit/11.3.0
 
 ## Run the main job
@@ -24,6 +23,4 @@ log_dir=log/${run_id}_${model_id}
 mkdir -p ${log_dir}
 # From Jeff's blogpost: https://github.com/jsadler2/wdfn-blog/blob/ca63d4dc4bf6aeb6962a58953057a41c9db1ad8a/content/snakemake-ml-experiments.md
 # Also see snakemake profiles: https://snakemake.readthedocs.io/en/stable/executing/cli.html#profiles
-# srun snakemake --cluster "sbatch -A watertemp -t 1-23:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" -p -k --cores all --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
-snakemake --cluster "srun -A watertemp -t 7:59:59 -p gpu -N 1 -n 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 1 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out
-
+snakemake --cluster "sbatch -A watertemp -t 00:20:00 -p gpu -N 1 -n 1 -c 1 --job-name=${run_id}_${model_id} --gres=gpu:1 -e ${log_dir}/slurm-%j.out -o ${log_dir}/slurm-%j.out" --printshellcmds --keep-going --cores all --jobs 8 --rerun-incomplete 3_train/out/mntoha/${run_id}/${model_id}_weights.pt 2>&1 | tee ${log_dir}/run.out


### PR DESCRIPTION
This PR addresses issues that arose when trying to train a model using a GPU on Tallgrass. Closes #30. The changes can be organized into four categories:

1. Training data and validation data are now on the same device (cpu or gpu) as the model.
    - Shouldn't need much attention. This issue caused a show-stopping error, and now it doesn't. 
    - I could ask Jeremy how he's handled this after the temperature sprint ends.
2. Missing packages added to conda environment
    - The weird addition here is git. Conda will now install the git executable. This is so that the git status can be logged - turns out that compute nodes don't have git installed on them. I'm open to other options, but this does work!
3. Slurm scripts for both cpu and gpu have been written
    - I'd appreciate eyes here - I'm not fluent in slurm scripts, plus there's snakemake in the mix.
    - I adapted the command in [Jeff's blog](https://github.com/jsadler2/wdfn-blog/blob/snakemake-dl-experiments/content/snakemake-ml-experiments.md) for the snakemake part.
4. Miscellaneous minor changes
    - Add `setup.sh` to setup the environment easily
    - Git ignore the `log` folder where slurm output is directed
    - Add `flush=True` to Python `print()` commands to flush stdout and keep the logs up to date while the model is training. Otherwise it's hard to track the progress during training.

# How to review this PR

This one's a hodgepodge! Since it consists mainly of bug fixes that were needed to get a model out, it's been through a round of informal testing. Don't worry if there are parts that aren't in your wheelhouse - feel free to focus on the aspects of the PR that you can easily review, and let me know if there are aspects that you skim over. 

## Where in the code to focus

Feedback on the slurm scripts would be especially welcome!
