### PR TITLE
Split validation set during 2_process

### DIFF
--- a/2_process.smk
+++ b/2_process.smk
@@ -456,8 +456,9 @@ rule create_training_data:
         sequences_summary_file = "2_process/out/{data_source}/sequences/{data_source}_sequences_summary.csv"
     output:
         train_file = "2_process/out/{data_source}/train.npz",
+        valid_file = "2_process/out/{data_source}/valid.npz",
         test_file = "2_process/out/{data_source}/test.npz",
-        train_test_summary_file = "2_process/out/{data_source}/train_test_summary.csv"
+        split_summary_file = "2_process/out/{data_source}/split_summary.csv"
     params:
         process_config = config
     script:

--- a/2_process/process_config.yaml
+++ b/2_process/process_config.yaml
@@ -13,7 +13,8 @@ depths: [0.0,  0.5,  1.0,  1.5,  2.0,  2.5,  3.0,  3.5,  4.0,  4.5,  5.0,
          140.0, 150.0, 160.0, 170.0, 180.0, 190.0, 200.0, 220.0, 240.0, 260.0]
 
 # train/test split
-train_frac: 0.8
+train_frac: 0.6
+valid_frac: 0.2
 test_frac: 0.2
 
 # input/output features


### PR DESCRIPTION
This PR splits validation data at the same point in the workflow and in the same manner as the testing data are split. The data are split by lake rather than by sequence. Splitting by lake means that the lakes used for validation data are always different than the lakes used for training data (and different than the lakes used for testing data). That way, validation metrics will better represent the model's performance on new lakes that aren't in the training set. So, early stopping should be even more effective at avoiding overfitting to the training data.

# How to run the code
The rule `create_training_data` creates training, validation, and testing sets. So, to run this part of the pipeline:
```
snakemake -c1 2_process/out/model_prep/train.npz
```
That should make `train.npz`, `valid.npz`, and `test.npz`.

# How to review this PR

## Level of review requested

The code seems to work - no lake site IDs appear in more than one split.

The main things I'd like reviewed are:

1. Do the pipeline additions and modifications make sense?
2. Have any errors been introduced into the pipeline?

## Where in the code to focus

Anything that's been changed is fair game, but the majority of the changes are in `training_data.py`.

## Issues that will be addressed in upcoming PRs (so don't worry about them yet)
- Save more metadata alongside train.npz, validate.npz, and test.npz for use during model evaluation
- Change directory structure to be more nested
