### PR TITLE
Save training metadata

### DIFF
--- a/2_process.smk
+++ b/2_process.smk
@@ -450,7 +450,7 @@ rule process_sequences:
 rule create_training_data:
     input:
         lambda wildcards: get_lake_sequence_files(
-            '2_process/out/{}/sequences/sequences_{}.npy',
+            '2_process/out/{}/sequences/sequences_{}.npz',
             wildcards.data_source
         ),
         sequences_summary_file = "2_process/out/{data_source}/sequences/{data_source}_sequences_summary.csv"

--- a/2_process.smk
+++ b/2_process.smk
@@ -424,7 +424,7 @@ def save_sequences_summary(lake_sequence_files_input, summary_file):
     sequence_counts = []
     for sequences_file in lake_sequence_files_input:
         # Sequence files have shape (# sequences, sequence length, # depths + # features)
-        num_sequences = np.load(sequences_file).shape[0] 
+        num_sequences = np.load(sequences_file)['lake_sequences'].shape[0] 
         sequence_counts.append(num_sequences)
     df_counts = pd.DataFrame(data={
         'sequences_file': lake_sequence_files_input,
@@ -437,7 +437,7 @@ def save_sequences_summary(lake_sequence_files_input, summary_file):
 rule process_sequences:
     input:
         lambda wildcards: get_lake_sequence_files(
-            '2_process/out/{}/sequences/sequences_{}.npy',
+            '2_process/out/{}/sequences/sequences_{}.npz',
             wildcards.data_source
         )
     output:

--- a/2_process.smk
+++ b/2_process.smk
@@ -334,14 +334,14 @@ def dynamic_filenames_model_prep(site_id):
     return [drivers_file]
 
 
-# Create .npy of input/output sequences for one lake to use for training and testing
+# Create .npz of input/output sequences for one lake to use for training and testing
 rule lake_sequences_model_prep:
     input:
         lake_metadata_file = "2_process/tmp/model_prep/lake_metadata_augmented.csv",
         observations_file = "2_process/tmp/model_prep/temperature_observations_interpolated.csv",
         dynamic_files = lambda wildcards: dynamic_filenames_model_prep(wildcards.site_id)
     output:
-        site_sequences_file = "2_process/out/model_prep/sequences/sequences_{site_id}.npy"
+        site_sequences_file = "2_process/out/model_prep/sequences/sequences_{site_id}.npz"
     params:
         temp_col = 'temp',
         depth_col = 'interpolated_depth',

--- a/2_process/src/training_data.py
+++ b/2_process/src/training_data.py
@@ -1,4 +1,4 @@
-# Read lake-specific sequences from .npy files and save .npz files for training and test data
+# Read lake-specific sequences from .npz files and save .npz files for training and test data
 
 import os
 import numpy as np
@@ -59,18 +59,19 @@ def read_sequences(lake_sequence_files, n_depths):
     among their input features, and return a single numpy array containing all
     sequences from all sequence files.
 
-    :param lake_sequence_files: List of lake sequence .npy files
+    :param lake_sequence_files: List of lake sequence .npz files
     :param n_depths: Number of discrete depths at which LSTM will output
         temperatures
     :returns: numpy array of sequences
 
     """
-    sequences = np.concatenate([np.load(sfn) for sfn in lake_sequence_files])
+    sequences = np.concatenate([np.load(lsfn)['lake_sequences'] for lsfn in lake_sequence_files])
+    start_dates = np.concatenate([np.load(lsfn)['start_dates'] for lsfn in lake_sequence_files])
     # remove input features with nans
     # shape of sequences is (# sequences, sequence_length, # depths + # input features)
     # slice from n_depths forward to index input features only
     nan_inputs = np.any(np.isnan(sequences[:, :, n_depths:]), axis=(1,2))
-    return sequences[np.invert(nan_inputs), :, :]
+    return (sequences[np.invert(nan_inputs), :, :], start_dates[np.invert(nan_inputs)])
 
 
 def split_sequence_files(sequences_summary_file,
@@ -117,9 +118,9 @@ def get_train_test_data(train_lake_sequences_files,
     """
     Create training, validation, and test data
     
-    This function takes data from lake-specific sequences in .npy files and
+    This function takes data from lake-specific sequences in .npz files and
     creates arrays for training, validation, and testing.
-    1. Read lake-specific sequences from .npy files and concatenate
+    1. Read lake-specific sequences from .npz files and concatenate
     2. Standardize using training data
 
     :param train_lake_sequences_files: List of lake sequence files in the
@@ -133,8 +134,10 @@ def get_train_test_data(train_lake_sequences_files,
     :param n_dynamic: Number of dynamic input features
     :param n_static: Number of static input features
     :returns: Tuple of four elements
-        1. 3D numpy array of training data
-        2. Numpy array of test data
+        1. Tuple of 3D Numpy arrays of training data, validation data, and
+           testing data
+        2. Tuple of Numpy arrays of start dates for sequences in training,
+           validation, and testing sets
         3. Numpy array of means of training data (input features and
            temperatures)
         4. Numpy array of standard deviations of training data (input features
@@ -142,11 +145,11 @@ def get_train_test_data(train_lake_sequences_files,
 
     """
 
-    # 1. Read lake-specific sequences from .npy files and concatenate
+    # 1. Read lake-specific sequences from .npz files and concatenate
 
-    unscaled_train_data = read_sequences(train_lake_sequences_files, n_depths)
-    unscaled_valid_data = read_sequences(valid_lake_sequences_files, n_depths)
-    unscaled_test_data = read_sequences(test_lake_sequences_files, n_depths)
+    unscaled_train_data, train_start_dates = read_sequences(train_lake_sequences_files, n_depths)
+    unscaled_valid_data, valid_start_dates = read_sequences(valid_lake_sequences_files, n_depths)
+    unscaled_test_data, test_start_dates = read_sequences(test_lake_sequences_files, n_depths)
 
     # 2. Standardize using training data
 
@@ -162,9 +165,11 @@ def get_train_test_data(train_lake_sequences_files,
     valid_data = (unscaled_valid_data - train_data_means)/train_data_stds
     test_data = (unscaled_test_data - train_data_means)/train_data_stds
 
-    return (train_data,
-            valid_data,
-            test_data,
+    split_data = (train_data, valid_data, test_data)
+    split_start_dates = (train_start_dates, valid_start_dates, test_start_dates)
+
+    return (split_data, 
+            split_start_dates,
             train_data_means,
             train_data_stds
            )
@@ -177,7 +182,7 @@ def main(sequences_summary_file,
          split_summary_file,
          process_config):
     """
-    Read lake-specific sequences from .npy files, save .npz files for training,
+    Read lake-specific sequences from .npz files, save .npz files for training,
     validation, and test data, and save a file listing which lakes went into
     each set.
 
@@ -202,7 +207,7 @@ def main(sequences_summary_file,
     )
 
     # Get training, validation, and test data
-    train_data, valid_data, test_data, train_data_means, train_data_stds = get_train_test_data(
+    split_data, split_start_dates, train_data_means, train_data_stds = get_train_test_data(
         train_lake_sequences_files,
         valid_lake_sequences_files,
         test_lake_sequences_files,
@@ -210,6 +215,10 @@ def main(sequences_summary_file,
         len(process_config['dynamic_features_all']),
         len(process_config['static_features_all'])
     )
+
+    # Unpack tuples
+    train_data, valid_data, test_data = split_data
+    train_start_dates, valid_start_dates, test_start_dates = split_start_dates
 
     # Create new directories as needed
     for filepath in [train_file, valid_file, test_file, split_summary_file]:
@@ -222,16 +231,19 @@ def main(sequences_summary_file,
     # keywords
     np.savez(train_file,
              data=train_data,
+             start_dates=train_start_dates,
              train_data_means=train_data_means,
              train_data_stds=train_data_stds,
              **process_config)
     np.savez(valid_file,
              data=valid_data,
+             start_dates=valid_start_dates,
              train_data_means=train_data_means,
              train_data_stds=train_data_stds,
              **process_config)
     np.savez(test_file,
              data=test_data,
+             start_dates=test_start_dates,
              train_data_means=train_data_means,
              train_data_stds=train_data_stds,
              **process_config)

--- a/2_process/src/training_data.py
+++ b/2_process/src/training_data.py
@@ -65,6 +65,8 @@ def read_sequences(lake_sequence_files, n_depths):
     :returns: numpy array of sequences
 
     """
+    # Read (1) sequences, (2) start dates, and (3) lake IDs from each lake
+    # sequence file, and concatenate them into three equal-length lists
     sequences_list = []
     start_dates_list = []
     site_ids_list = []
@@ -90,7 +92,7 @@ def read_sequences(lake_sequence_files, n_depths):
     start_dates = np.concatenate(start_dates_list)
     site_ids = np.concatenate(site_ids_list)
 
-    # Remove input features with nans
+    # Trim all three lists equally to remove all sequences with any NaN input features
     # Shape of sequences is (# sequences, sequence_length, # depths + # input features)
     # Slice from n_depths forward to index input features only
     nan_inputs = np.any(np.isnan(sequences[:, :, n_depths:]), axis=(1,2))


### PR DESCRIPTION
This PR ensures that metadata are saved alongside the sequences in the training, validation, and testing sets.

Previously, when data were organized into `train.npz`, `valid.npz`, and `test.npz` as equal-length sequences, information about **WHEN** those sequences start or **WHICH LAKE** they belong to was not saved, because that information isn't relevant to training the neural network. However, that information is relevant to evaluating the neural network. Therefore, in this PR those metadata are added to the npz files. That way, `test.npz` can be used to examine model performance during different seasons and in specific lakes or sets of lakes.

The metadata are saved in the three npz files as as additional arrays with the same length as the number of sequences. That is, there is one start date and one lake ID per sequence.

# How to run the code
The rule `create_training_data` creates training, validation, and testing sets. So, to run this part of the pipeline:
```
snakemake -c1 2_process/out/model_prep/train.npz
```
That should make `train.npz`, `valid.npz`, and `test.npz`, now with additional files `start_dates` and `site_ids`.

# How to review this PR

## Level of review requested

The code seems to work - data appear in the npzs where expected.

The main things I'd like reviewed are:

1. Do the pipeline additions and modifications make sense?
2. Have any errors been introduced?

## Where in the code to focus

Anything that's been changed is fair game, but the majority of the changes are in `lake_sequences.py` and `training_data.py`.

## Issues that will be addressed in upcoming PRs (so don't worry about them yet)
- Changes to 3_train functions that accommodate these updates
- Change directory structure to be more nested
