### PR TITLE
Early stopping

### DIFF
--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -253,7 +253,7 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
     return loss.item(), torch.sum(loss_idx).item()
 
 
-def fit(epochs, model, loss_func, opt, train_dl, valid_dl, device, verbose=False):
+def fit(epochs, model, loss_func, opt, train_dl, valid_dl, device, weights_filepath, verbose=False):
     """
     Train the model, and compute training and validation losses for each epoch
     
@@ -320,6 +320,11 @@ def fit(epochs, model, loss_func, opt, train_dl, valid_dl, device, verbose=False
         print(f'{epoch}: {datetime.now()} {train_loss}, {valid_loss}', flush=True)
         train_losses.append(train_loss)
         valid_losses.append(valid_loss)
+
+        # If this model has the lowest validation loss, save model weights
+        if valid_loss == min(valid_losses):
+            save_weights(model, weights_filepath, overwrite=True)
+
     return train_losses, valid_losses
 
 
@@ -523,12 +528,17 @@ def main(train_npz_filepath,
 
     # Training loop
     train_start_time = str(datetime.now())
-    train_losses, valid_losses = fit(config['max_epochs'], model, loss_func, optimizer, train_data_loader, valid_data_loader, device)
+    train_losses, valid_losses = fit(config['max_epochs'],
+                                     model,
+                                     loss_func,
+                                     optimizer,
+                                     train_data_loader,
+                                     valid_data_loader,
+                                     device,
+                                     weights_filepath)
     train_end_time = str(datetime.now())
     print('Finished Training', flush=True)
 
-    # Save model weights
-    save_weights(model, weights_filepath, overwrite=True)
     # Save model settings and training metrics
     config['model_id'] = model_id
     config['train_start_time'] = train_start_time

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -92,9 +92,9 @@ def get_data_loaders(train_ds, valid_ds, batch_size):
 
 
 def get_sequence_dataset(npz_filepath,
-                        dynamic_features_use,
-                        static_features_use,
-                        depths_use):
+                         dynamic_features_use,
+                         static_features_use,
+                         depths_use):
     """
     Get SequenceDataset from npz file
     
@@ -169,15 +169,13 @@ def get_data(train_npz_filepath,
     return get_data_loaders(train_subset, valid_subset, batch_size)
 
 
-def get_model(
-    n_depths,
-    n_dynamic,
-    n_static,
-    hidden_size,
-    initial_forget_bias,
-    dropout,
-    concat_static
-):
+def get_model(n_depths,
+              n_dynamic,
+              n_static,
+              hidden_size,
+              initial_forget_bias,
+              dropout,
+              concat_static):
     """
     Create LSTM or EA-LSTM torch model
     
@@ -253,7 +251,16 @@ def loss_batch(model, loss_func, x_d, x_s, y, opt=None):
     return loss.item(), torch.sum(loss_idx).item()
 
 
-def fit(max_epochs, model, loss_func, opt, train_dl, valid_dl, device, weights_filepath, early_stopping_patience, verbose=False):
+def fit(max_epochs,
+        model,
+        loss_func,
+        opt,
+        train_dl,
+        valid_dl,
+        device,
+        weights_filepath,
+        early_stopping_patience,
+        verbose=False):
     """
     Train the model, and compute training and validation losses for each epoch
     
@@ -266,6 +273,7 @@ def fit(max_epochs, model, loss_func, opt, train_dl, valid_dl, device, weights_f
     :param train_dl: PyTorch DataLoader with training data
     :param valid_dl: PyTorch DataLoader with validation data
     :param device: Device that pytorch is running on (cpu or gpu)
+    :param weights_filepath: Path and filename to save model weights to
     :param early_stopping_patience: Number of epochs to train without
         validation loss improvement, i.e., training stops after
         early_stopping_patience epochs without improvement in the validation
@@ -441,7 +449,7 @@ def save_metadata(config, train_npz_filepath, valid_npz_filepath, save_filepath,
 def get_git_hash():
     """
     Get the hash of the current git revision
-
+    
     From https://stackoverflow.com/questions/14989858/get-the-current-git-hash-in-a-python-script
 
     :returns: String of current git revision's hash

--- a/3_train/src/train.py
+++ b/3_train/src/train.py
@@ -330,20 +330,23 @@ def fit(max_epochs, model, loss_func, opt, train_dl, valid_dl, device, weights_f
         train_losses.append(train_loss)
         valid_losses.append(valid_loss)
 
-        # If this model has the lowest validation loss, save model weights
-        if valid_loss == min(valid_losses):
-            num_epochs_without_improvement = 0
-            saved_epoch = epoch
-            save_weights(model, weights_filepath, overwrite=True)
-        # Otherwise, add to count of high validation loss models and check for early stopping condition
-        else:
-            num_epochs_without_improvement += 1
-            # An early_stopping_patience of -1 means early stopping should not happen
-            if early_stopping_patience != -1:
+        if early_stopping_patience != -1:
+            # If this model has the lowest validation loss, save model weights
+            if valid_loss == min(valid_losses):
+                num_epochs_without_improvement = 0
+                saved_epoch = epoch
+                save_weights(model, weights_filepath, overwrite=True)
+            # Otherwise, add to count of high validation loss models and check for early stopping condition
+            else:
+                num_epochs_without_improvement += 1
+                # An early_stopping_patience of -1 means early stopping should not happen
                 if num_epochs_without_improvement >= early_stopping_patience:
                     print(f'Stopping at epoch {epoch} after {num_epochs_without_improvement} epochs without improvement', flush=True)
                     break
 
+    if early_stopping_patience == -1:
+        saved_epoch = epoch
+        save_weights(model, weights_filepath, overwrite=True)
     return train_losses, valid_losses, saved_epoch
 
 


### PR DESCRIPTION
This PR implements early stopping with a user-defined patience. With early stopping implemented, training will continue until either

1. `early_stopping_patience` training epochs pass without a decrease in validation loss, or
2. `max_epochs` is reached.

These variables are defined in `3_train/in/{data_source}/{run_id}.yaml`. Model weights for the epoch with the lowest validation loss (not necessarily the final training epoch) are saved.

# How to run the code
These changes all concern the rule `train_model` in `3_train.smk`. So, to run this part of the pipeline, first copy `3_train/in/example_config.yaml` to `3_train/in/model_prep/1.yaml`. Then:
```
snakemake --cores all 3_train/out/model_prep/1/a_weights.pt
```
That should make `3_train/out/model_prep/1/1_process.yaml`, `3_train/out/model_prep/1/a_metadata.npz`, `3_train/out/model_prep/1/a_weights.pt`, and `3_train/out/model_prep/1/1_train.yaml`.

# How to review this PR

## Level of review requested

The main things I'd like reviewed are:

1. Does the implementation of early stopping look correct?
2. Should any related code additions or tweaks be made?
3. Have any errors been introduced?
4. Are the comments clear?

## Where in the code to focus

Anything that's been changed is fair game!

## Issues that are slated for upcoming PRs (so don't worry about them yet)
- Change directory structure to be more nested
