### PR TITLE
Add elevation and area metric plots

### DIFF
--- a/5_visualize.smk
+++ b/5_visualize.smk
@@ -9,7 +9,7 @@ rule plot_metric:
         train_predictions_filepath = "4_evaluate/out/{data_source}/{run_id}/{model_id}/interpolated_predictions_train.csv",
     params:
         include_train_mean = True,
-        doy_bin_width = 5
+        bin_width = None
     output:
         plot_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/{metric}-by-{plot_by}-over-{dataset}.png"
     script:
@@ -25,7 +25,11 @@ rule plot_all_metrics:
         rmse_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-depth-over-{dataset}.png",
         bias_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-depth-over-{dataset}.png",
         rmse_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-doy-over-{dataset}.png",
-        bias_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-doy-over-{dataset}.png"
+        bias_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-doy-over-{dataset}.png",
+        rmse_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-elevation-over-{dataset}.png",
+        bias_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-elevation-over-{dataset}.png",
+        rmse_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-area-over-{dataset}.png",
+        bias_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-area-over-{dataset}.png"
     output:
         dummyfile = "5_visualize/out/{data_source}/{run_id}/{model_id}/plot_all_{dataset}.dummy"
     shell:

--- a/5_visualize/src/plot_metrics.py
+++ b/5_visualize/src/plot_metrics.py
@@ -6,18 +6,34 @@ import hvplot.pandas
 import holoviews as hv
 
 
-def load_predictions(predictions_filepath, doy_bin_width):
+def load_predictions(predictions_filepath, 
+                     lake_metadata_filepath=None,
+                     plot_by=None,
+                     bin_width=None,
+                     bin_type='linear'):
     """
     Load predictions for one dataset from a csv as a pandas Dataframe.
     Load the predictions for the training, validation, or testing set. Remove
     any NaN predictions. Compute residuals (as observed - predicted) and save
     them as an extra column in the dataframe.
 
-    :param predictions_filepath: Path to predictions csv
-    :param doy_bin_width: Number of days to bin day of year to. For example, a
-        doy_bin_width of 7 means that the values in the column doy_bin will
-        increase by 7 at a time. Useful for smoothing out plots of metrics by
-        day of year.
+    :param predictions_filepath: Path to predictions csv to load
+    :param lake_metadata_filepath: Path to lake metadata csv (Default value =
+        None). If None, do not include lake metadata in returned dataframe.
+    :param plot_by: Independent variable for evaluating metric: 'lake',
+        'depth', 'doy', 'elevation', or 'area' (Default value = None).
+    :param bin_width: Width of bin for plot_by variable (Default value = None).
+        For example, a bin_width of 7 for `plot_by='doy'` means that the values
+        in the column doy_bin will increase by 7 at a time. Useful for
+        smoothing out plots of metrics.
+    :param bin_type: Type of spacing for bins: linear or logarthmic (Default
+        value = 'linear'). Some variables like surface area vary over several
+        orders of magnitude, and logarthmic spacing is a better choice for such
+        variables.
+    :returns: Pandas dataframe of observations, predictions, residuals, and day
+        of year with all NaN predictions removed. Optionally, lake metadata may
+        be merged into the dataframe, or a column may be binned for the purpose
+        of plotting and evaluation.
 
     """
     raw_preds = pd.read_csv(predictions_filepath, parse_dates=['date'])
@@ -27,8 +43,21 @@ def load_predictions(predictions_filepath, doy_bin_width):
     non_nan_preds['residual'] = non_nan_preds['temp'] - non_nan_preds['predicted_temperature_obs_depth']
     # Add a column for day of year
     non_nan_preds['doy'] = non_nan_preds['date'].dt.day_of_year
-    # Add a column for binned day of year
-    non_nan_preds['doy_bin'] = (doy_bin_width*round((non_nan_preds['doy'].astype(float))/doy_bin_width)).astype(int)
+    if lake_metadata_filepath is not None:
+        # Augment with lake metadata
+        lake_metadata = pd.read_csv(lake_metadata_filepath, index_col=0)
+        non_nan_preds = pd.merge(non_nan_preds, lake_metadata, how='left', on='site_id')
+    # Add a column for binned plot_by variable
+    if bin_width is not None:
+        bin_column_name = plot_by + '_bin'
+        if bin_type=='linear':
+            non_nan_preds[bin_column_name] = (
+                bin_width * round((non_nan_preds[plot_by].astype(float))/bin_width)
+            ).astype(int)
+        elif bin_type=='logarithmic':
+            non_nan_preds[bin_column_name] = 10**(bin_width*np.round(np.log10(non_nan_preds[plot_by].astype(float))/bin_width))
+        else:
+            raise ValueError(f'Binning data by {bin_type} type is not supported')
     return non_nan_preds
 
 
@@ -37,7 +66,10 @@ def rms(df):
     Return root mean squared of a Pandas Series or Dataframe. Useful as
     argument to groupby().aggregate().
 
-    :param df: Pandas Series or Dataframe to compute RMS for
+    :param df: Pandas Series or Dataframe or Numpy array-like over which to
+        compute RMS
+    :returns: RMS evaluated over df (each column of Dataframe or over entire
+        Series or array)
 
     """
     return np.sqrt((df**2).mean())
@@ -50,7 +82,8 @@ def plot_by_lake(agg_metric, lake_metadata_filepath, metric):
     :param agg_metric: Pandas Dataframe with aggregated metrics for each lake
     :param lake_metadata_filepath: Path to lake metadata csv
     :param metric: Metric to plot, 'rmse' or 'bias'. Used to determine colormap
-    for points (diverging for bias, sequential for rmse)
+        for points (diverging for bias, sequential for rmse)
+    :returns: Holoviews plot
 
     """
     # Augment with lake metadata
@@ -79,7 +112,7 @@ def plot_metric(predictions_filepath, metric, plot_by,
                 lake_metadata_filepath=None,
                 train_predictions_filepath=None,
                 include_train_mean=False,
-                doy_bin_width=1):
+                bin_width=1):
     """
     Plot a metric (e.g. RMS error) as a function of some variable (e.g. lake depth).
     
@@ -96,24 +129,35 @@ def plot_metric(predictions_filepath, metric, plot_by,
     :param predictions_filepath: Path to predictions csv
     :param metric: Metric to plot: 'rmse' or 'bias'
     :param plot_by: Independent variable for evaluating metric: 'lake',
-        'depth', or 'doy'
+        'depth', 'doy', 'elevation', or 'area'
     :param lake_metadata_filepath: Path to lake metadata csv (Default value =
         None). Only needed for plotting by lake, to get lake latitude and
         longitude.
     :param train_predictions_filepath: Path to training set predictions csv (Default value = None)
     :param include_train_mean: Whether to include metrics for the mean of the
         training set in the plot (Default value = False).
-    :param doy_bin_width: Number of days to bin day of year to (Default value =
-        1). For example, a doy_bin_width of 7 means that the values in the
-        column doy_bin will increase by 7 at a time. Useful for smoothing out
-        plots of metrics by day of year.
+    :param bin_width: Width of bin for plot_by variable (Default value = 1).
+        For example, a bin_width of 7 for `plot_by='doy'` means that the values
+        in the column doy_bin will increase by 7 at a time. Useful for
+        smoothing out plots of metrics.
+    :returns: Holoviews plot
 
     """
     # Dictionary relating inputs to column names
     prediction_columns = {
         'lake': 'site_id',
         'depth': 'interpolated_depth',
-        'doy': 'doy_bin'
+        'doy': 'doy_bin',
+        'area': 'area_bin',
+        'elevation': 'elevation_bin'
+    }
+    # Dictionary relating inputs to binning methods
+    bin_types = {
+        'lake': None,
+        'depth': None, # already binned
+        'doy': 'linear',
+        'area': 'logarithmic',
+        'elevation': 'linear'
     }
     # Dictionary relating inputs to aggregating functions
     agg_functions = {
@@ -121,7 +165,11 @@ def plot_metric(predictions_filepath, metric, plot_by,
         'bias': 'mean'
     }
 
-    preds = load_predictions(predictions_filepath, doy_bin_width)
+    preds = load_predictions(predictions_filepath,
+                             lake_metadata_filepath,
+                             plot_by,
+                             bin_width,
+                             bin_type=bin_types[plot_by])
 
     # Aggregate metric of residuals by a variable
     agg_metric = (
@@ -138,7 +186,11 @@ def plot_metric(predictions_filepath, metric, plot_by,
             # For comparison, take the mean of the training set and use it as a predictor to get residuals
             # This shows visually where prediction is more challenging due to observation variance
             # or difference from the training data
-            train_preds = load_predictions(train_predictions_filepath, doy_bin_width)
+            train_preds = load_predictions(train_predictions_filepath,
+                                           lake_metadata_filepath,
+                                           plot_by,
+                                           bin_width,
+                                           bin_type=bin_types[plot_by])
             train_mean_temp = train_preds.groupby(prediction_columns[plot_by])['temp'].mean().rename('train_mean_temp')
             preds_train_mean = preds.merge(train_mean_temp, how='left', on=prediction_columns[plot_by]).copy()
             preds_train_mean['train_mean_residual'] = preds_train_mean['temp'] - preds_train_mean['train_mean_temp']
@@ -162,6 +214,16 @@ def plot_metric(predictions_filepath, metric, plot_by,
                 p = df_plot.hvplot.line() * zero_line
             else:
                 p = df_plot.hvplot.line()
+        elif plot_by == 'area':
+            if metric == 'bias':
+                p = df_plot.hvplot.line().opts(logx=True) * zero_line
+            else:
+                p = df_plot.hvplot.line().opts(logx=True)
+        elif plot_by == 'elevation':
+            if metric == 'bias':
+                p = df_plot.hvplot.line() * zero_line
+            else:
+                p = df_plot.hvplot.line()
         else:
             raise ValueError(f'Evaluating metrics by {plot_by} is not supported')
 
@@ -172,7 +234,7 @@ def save_metric_plot(plot_filepath, predictions_filepath, metric, plot_by,
                      lake_metadata_filepath=None,
                      train_predictions_filepath=None,
                      include_train_mean=False,
-                     doy_bin_width=1):
+                     bin_width=1):
     """
     Save a plot of a metric (e.g. RMS error) as a function of some variable
     (e.g. lake depth).
@@ -192,24 +254,23 @@ def save_metric_plot(plot_filepath, predictions_filepath, metric, plot_by,
     :param predictions_filepath: Path to predictions csv
     :param metric: Metric to plot: 'rmse' or 'bias'
     :param plot_by: Independent variable for evaluating metric: 'lake',
-        'depth', or 'doy'
+        'depth', 'doy', 'elevation', or 'area'
     :param lake_metadata_filepath: Path to lake metadata csv (Default value =
-        None). Only needed for plotting by lake, to get lake latitude and
-        longitude.
+        None).
     :param train_predictions_filepath: Path to training set predictions csv (Default value = None)
     :param include_train_mean: Whether to include metrics for the mean of the
         training set in the plot (Default value = False).
-    :param doy_bin_width: Number of days to bin day of year to (Default value =
-        1). For example, a doy_bin_width of 7 means that the values in the
-        column doy_bin will increase by 7 at a time. Useful for smoothing out
-        plots of metrics by day of year.
+    :param bin_width: Width of bin for plot_by variable (Default value = 1).
+        For example, a bin_width of 7 for `plot_by='doy'` means that the values
+        in the column doy_bin will increase by 7 at a time. Useful for
+        smoothing out plots of metrics.
 
     """
     p = plot_metric(predictions_filepath, metric, plot_by,
                     lake_metadata_filepath=lake_metadata_filepath,
                     train_predictions_filepath=train_predictions_filepath,
                     include_train_mean=include_train_mean,
-                    doy_bin_width=doy_bin_width)
+                    bin_width=bin_width)
     destination_dir = os.path.dirname(plot_filepath)
     if not os.path.exists(destination_dir):
         os.makedirs(destination_dir)
@@ -217,6 +278,17 @@ def save_metric_plot(plot_filepath, predictions_filepath, metric, plot_by,
 
 
 if __name__ == '__main__':
+    if snakemake.params.bin_width is None:
+        bin_widths = {
+            'lake': None,
+            'depth': None,
+            'doy': 5,
+            'area': 0.25, # in base 10 orders of magnitude
+            'elevation': 50 # in meters
+        }
+        bin_width = bin_widths[snakemake.wildcards['plot_by']]
+    else:
+        bin_width = snakemake.params.bin_width
     save_metric_plot(snakemake.output.plot_filepath,
                      snakemake.input.interpolated_predictions_filepath,
                      snakemake.wildcards['metric'],
@@ -224,6 +296,6 @@ if __name__ == '__main__':
                      lake_metadata_filepath=snakemake.input.lake_metadata_filepath,
                      train_predictions_filepath=snakemake.input.train_predictions_filepath,
                      include_train_mean=snakemake.params.include_train_mean,
-                     doy_bin_width=snakemake.params.doy_bin_width)
+                     bin_width=bin_width)
 
 


### PR DESCRIPTION
Per Jeremy's suggestion in [#48](https://github.com/USGS-R/lake-temperature-lstm-static/pull/48#issuecomment-1243961974): 
> Some other potentially interesting dimensions to view error/bias along might include elevation and lake area.

This PR adds plots of RMS error and bias for the variables elevation and area. The plots can, optionally, include metrics evaluated against the mean of the training data (e.g., for elevation, take the mean temperature of all lakes in each elevation bin and compute RMS error and bias). Every lake has a different elevation and area, so in order to make meaningful plots, elevation and area need to be binned. 

## How to run the code

- Create all validation plots.
```bash
snakemake -c all -r -s 5_visualize.smk 5_visualize/out/model_prep/initial/cpu_a/plot_all_valid.dummy
```

This code has been run locally with success.

## Results

### RMSE by elevation over validation set
![rmse-by-elevation-over-valid](https://user-images.githubusercontent.com/11847289/189965185-436bde2e-01a6-4a3d-a246-67c21b4c5190.png)

### Bias by elevation over validation set
![bias-by-elevation-over-valid](https://user-images.githubusercontent.com/11847289/189965369-e3f59524-7358-4810-a1ed-1cc0c99672f8.png)

### RMSE by area over validation set
![rmse-by-area-over-valid](https://user-images.githubusercontent.com/11847289/189965407-a9c07087-7b2a-4b8b-ae30-7ec32987eeac.png)

### Bias by area over validation set
![bias-by-area-over-valid](https://user-images.githubusercontent.com/11847289/189965431-7102cab5-a469-49e7-9fa2-f3cb347941f5.png)

## How to review this PR

- Are there any obvious errors?

Hopefully this review isn't too time-intensive.

### Issues that will be addressed in upcoming PRs (so don't worry about them yet)

- Change to a different plotting library - probably `seaborn`
- Plot histograms of observation data density per #49 

Closes #50 