### PR TITLE
Plot obs counts

### DIFF
--- a/5_visualize.smk
+++ b/5_visualize.smk
@@ -16,26 +16,6 @@ rule plot_metric:
         "5_visualize/src/plot_metrics.py"
 
 
-# Plot all metrics for one model and one dataset
-rule plot_all_metrics:
-    input:
-        interpolated_predictions_filepath = "4_evaluate/out/{data_source}/{run_id}/{model_id}/interpolated_predictions_{dataset}.csv",
-        rmse_lake_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-lake-over-{dataset}.png",
-        bias_lake_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-lake-over-{dataset}.png",
-        rmse_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-depth-over-{dataset}.png",
-        bias_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-depth-over-{dataset}.png",
-        rmse_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-doy-over-{dataset}.png",
-        bias_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-doy-over-{dataset}.png",
-        rmse_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-elevation-over-{dataset}.png",
-        bias_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-elevation-over-{dataset}.png",
-        rmse_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-area-over-{dataset}.png",
-        bias_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-area-over-{dataset}.png"
-    output:
-        dummyfile = "5_visualize/out/{data_source}/{run_id}/{model_id}/plot_all_{dataset}.dummy"
-    shell:
-        "touch {output.dummyfile}"
-
-
 # Plot histograms of observations
 rule plot_obs_count:
     input:
@@ -45,5 +25,30 @@ rule plot_obs_count:
         plot_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-{plot_by}-over-{dataset}.png"
     script:
         "5_visualize/src/plot_obs_counts.py"
+
+
+# Plot all metrics for one model and one dataset
+rule plot_all_metrics:
+    input:
+        interpolated_predictions_filepath = "4_evaluate/out/{data_source}/{run_id}/{model_id}/interpolated_predictions_{dataset}.csv",
+        rmse_lake_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-lake-over-{dataset}.png",
+        bias_lake_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-lake-over-{dataset}.png",
+        rmse_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-depth-over-{dataset}.png",
+        bias_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-depth-over-{dataset}.png",
+        obs_count_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-depth-over-{dataset}.png",
+        rmse_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-doy-over-{dataset}.png",
+        bias_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-doy-over-{dataset}.png",
+        obs_count_doy_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-doy-over-{dataset}.png",
+        rmse_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-elevation-over-{dataset}.png",
+        bias_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-elevation-over-{dataset}.png",
+        obs_count_elevation_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-elevation-over-{dataset}.png",
+        rmse_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/rmse-by-area-over-{dataset}.png",
+        bias_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/bias-by-area-over-{dataset}.png",
+        obs_count_area_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-area-over-{dataset}.png",
+        obs_count_doy_depth_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-doy_depth-over-{dataset}.png",
+    output:
+        dummyfile = "5_visualize/out/{data_source}/{run_id}/{model_id}/plot_all_{dataset}.dummy"
+    shell:
+        "touch {output.dummyfile}"
 
 

--- a/5_visualize.smk
+++ b/5_visualize.smk
@@ -11,7 +11,7 @@ rule plot_metric:
         include_train_mean = True,
         bin_width = None
     output:
-        plot_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/{metric}-by-{plot_by}-over-{dataset}.png"
+        plot_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/{metric,rmse|bias}-by-{plot_by}-over-{dataset}.png"
     script:
         "5_visualize/src/plot_metrics.py"
 
@@ -34,4 +34,16 @@ rule plot_all_metrics:
         dummyfile = "5_visualize/out/{data_source}/{run_id}/{model_id}/plot_all_{dataset}.dummy"
     shell:
         "touch {output.dummyfile}"
+
+
+# Plot histograms of observations
+rule plot_obs_count:
+    input:
+        predictions_filepath = "4_evaluate/out/{data_source}/{run_id}/{model_id}/interpolated_predictions_{dataset}.csv",
+        lake_metadata_filepath = "2_process/tmp/{data_source}/lake_metadata_augmented.csv"
+    output:
+        plot_filepath = "5_visualize/out/{data_source}/{run_id}/{model_id}/obs-count-by-{plot_by}-over-{dataset}.png"
+    script:
+        "5_visualize/src/plot_obs_counts.py"
+
 

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -55,7 +55,6 @@ def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwar
         ax.set_ylabel('Number of observations')
     elif plot_by == 'doy_depth':
         # Number of observations by day of year and depth
-        fig, ax = plt.subplots()
         hexbin = ax.hexbin(preds.doy, preds.depth, bins='log', **kwargs)
         cbar = plt.colorbar(hexbin)
         cbar.set_label('Number of observations')

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -9,9 +9,22 @@ from plot_metrics import load_predictions
 
 def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
     """
+    Plot the density of observation data as a histogram or hexbin plot, as a
+    function of some variable (e.g. lake depth).
+
+    :param predictions_filepath: Path to predictions csv to load
+    :param lake_metadata_filepath: Path to lake metadata csv
+    :param plot_by: Independent variable for plot: 
+        'elevation', 'area', 'depth', 'doy', or 'doy_depth'. If 'doy_depth', a
+        hexbin is plotted with day of year on the horizontal axis and depth on
+        the vertical axis.
+    :param **kwargs: Keyword arguments to pass through to call to library
+        plotting function (sns.histplot or plt.hexbin)
+    :returns: Matplotlib figure
+
     """
 
-    preds = load_predictions(predictions_filepath, lake_metadata_filepath, None, None)
+    preds = load_predictions(predictions_filepath, lake_metadata_filepath=lake_metadata_filepath)
 
     fig, ax = plt.subplots()
     if plot_by == 'area':
@@ -55,6 +68,18 @@ def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwar
 
 def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
     """
+    Save a plot of the density of observation data as a histogram or hexbin
+    plot, as a function of some variable (e.g. lake depth) to a file.
+
+    :param plot_filepath: Path to save plot image to. Image format is
+        determined from extension.
+    :param predictions_filepath: Path to predictions csv to load
+    :param lake_metadata_filepath: Path to lake metadata csv
+    :param plot_by: Independent variable for evaluating metric: 
+        'depth', 'doy', 'elevation', or 'area'
+    :param **kwargs: Keyword arguments to pass through to call to library
+        plotting function (sns.histplot or plt.hexbin)
+
     """
     fig = plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
     fig.savefig(plot_filepath)

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -82,6 +82,7 @@ def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filep
 
     """
     fig = plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
+    plt.tight_layout()
     fig.savefig(plot_filepath)
 
 

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -1,0 +1,61 @@
+import numpy as np
+import pandas as pd
+import matplotlib.pyplot as plt
+import seaborn as sns
+
+import sys
+sys.path.insert(1, '5_visualize/src')
+from plot_metrics import load_predictions
+
+def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
+    """
+    """
+
+    preds = load_predictions(predictions_filepath, lake_metadata_filepath, None, None)
+
+    fig, ax = plt.subplots()
+    if plot_by == 'area':
+        # Number of observations by lake surface area
+        min_value = preds['area'].min()
+        max_value = preds['area'].max()
+        logbins = np.logspace(np.log10(min_value), np.log10(max_value), 50)
+        hist = sns.histplot(preds['area'], bins=logbins, ax=ax, **kwargs)
+        plt.xscale('log')
+        ax.set_xlabel('Lake surface area')
+        ax.set_ylabel('Number of observations')
+    elif plot_by == 'depth':
+        # Number of observations by depth
+        hist = sns.histplot(preds['interpolated_depth'], bins=50, ax=ax, **kwargs)
+        # plt.yscale('log')
+        ax.set_xlabel('Lake depth')
+        ax.set_ylabel('Number of observations')
+    elif plot_by == 'elevation':
+        # Number of observations by elevation
+        hist = sns.histplot(preds['elevation'], bins=50, ax=ax, **kwargs)
+        # plt.yscale('log')
+        ax.set_xlabel('Elevation')
+        ax.set_ylabel('Number of observations')
+    elif plot_by == 'doy':
+        # Number of observations by day of year
+        hist = sns.histplot(preds['doy'], bins=50, ax=ax, **kwargs)
+        ax.set_xlabel('Day of year')
+        ax.set_ylabel('Number of observations')
+    elif plot_by == 'doy_depth':
+        # Number of observations by day of year and depth
+        fig, ax = plt.subplots()
+        hexbin = ax.hexbin(preds.doy, preds.depth, bins='log', **kwargs)
+        cbar = plt.colorbar(hexbin)
+        cbar.set_label('Number of observations')
+        ax.set_xlabel('Day of year')
+        ax.set_ylabel('Lake depth (meters)')
+        ax.invert_yaxis()
+    else:
+        raise ValueError(f'Plotting observation counts by {plot_by} is not supported')
+    return fig
+
+def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
+    """
+    """
+    fig = plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
+    fig.savefig(plot_filepath)
+

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -7,11 +7,12 @@ import sys
 sys.path.insert(1, '5_visualize/src')
 from plot_metrics import load_predictions
 
-def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
+def plot_obs_count(ax, predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
     """
     Plot the density of observation data as a histogram or hexbin plot, as a
     function of some variable (e.g. lake depth).
 
+    :param ax: matplotlib axes object to plot to
     :param predictions_filepath: Path to predictions csv to load
     :param lake_metadata_filepath: Path to lake metadata csv
     :param plot_by: Independent variable for plot: 
@@ -20,32 +21,30 @@ def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwar
         the vertical axis.
     :param **kwargs: Keyword arguments to pass through to call to library
         plotting function (sns.histplot or plt.hexbin)
-    :returns: Matplotlib figure
 
     """
 
     preds = load_predictions(predictions_filepath, lake_metadata_filepath=lake_metadata_filepath)
 
-    fig, ax = plt.subplots()
     if plot_by == 'area':
         # Number of observations by lake surface area
         min_value = preds['area'].min()
         max_value = preds['area'].max()
         logbins = np.logspace(np.log10(min_value), np.log10(max_value), 50)
-        hist = sns.histplot(preds['area'], bins=logbins, ax=ax, **kwargs)
-        plt.xscale('log')
+        hist = sns.histplot(preds['area'], bins=logbins, ax=ax, edgecolor='black', linewidth=0.5, **kwargs)
+        ax.set_xscale('log')
         ax.set_xlabel('Lake surface area')
         ax.set_ylabel('Number of observations')
     elif plot_by == 'depth':
         # Number of observations by depth
         hist = sns.histplot(preds['interpolated_depth'], bins=50, ax=ax, **kwargs)
-        # plt.yscale('log')
+        # ax.set_yscale('log')
         ax.set_xlabel('Lake depth')
         ax.set_ylabel('Number of observations')
     elif plot_by == 'elevation':
         # Number of observations by elevation
         hist = sns.histplot(preds['elevation'], bins=50, ax=ax, **kwargs)
-        # plt.yscale('log')
+        # ax.set_yscale('log')
         ax.set_xlabel('Elevation')
         ax.set_ylabel('Number of observations')
     elif plot_by == 'doy':
@@ -63,7 +62,6 @@ def plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwar
         ax.invert_yaxis()
     else:
         raise ValueError(f'Plotting observation counts by {plot_by} is not supported')
-    return fig
 
 def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filepath, plot_by, **kwargs):
     """
@@ -80,7 +78,8 @@ def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filep
         plotting function (sns.histplot or plt.hexbin)
 
     """
-    fig = plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
+    fig, ax = plt.subplots()
+    plot_obs_count(ax, predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
     plt.tight_layout()
     fig.savefig(plot_filepath)
 

--- a/5_visualize/src/plot_obs_counts.py
+++ b/5_visualize/src/plot_obs_counts.py
@@ -59,3 +59,11 @@ def save_obs_count_plot(plot_filepath, predictions_filepath, lake_metadata_filep
     fig = plot_obs_count(predictions_filepath, lake_metadata_filepath, plot_by, **kwargs)
     fig.savefig(plot_filepath)
 
+
+if __name__ == '__main__':
+    save_obs_count_plot(snakemake.output.plot_filepath,
+                        snakemake.input.predictions_filepath,
+                        snakemake.input.lake_metadata_filepath,
+                        snakemake.wildcards['plot_by'])
+
+

--- a/environment_hpc.yaml
+++ b/environment_hpc.yaml
@@ -16,6 +16,7 @@ dependencies:
   - r-base
   - numpy
   - matplotlib
+  - seaborn
   - scipy
   - git
   - jupyterlab

--- a/environment_local.yaml
+++ b/environment_local.yaml
@@ -15,6 +15,7 @@ dependencies:
   - r-base
   - numpy
   - matplotlib
+  - seaborn
   - scipy
   - git
   - jupyterlab


### PR DESCRIPTION
Per Jeremy's suggestion in [#48](https://github.com/USGS-R/lake-temperature-lstm-static/pull/48#issuecomment-1243961974), histograms showing observation data density provide important context when evaluating model performance. This PR adds those histograms to the pipeline. Histograms of number of observations can be plotted for the variables elevation, area, day of year, and depth. Additionally, a hexbin plot with day of year on the horizontal axis and depth on the vertical axis can be plotted. 

## How to run the code

- Create all validation plots.
```bash
snakemake -c all -r -s 5_visualize.smk 5_visualize/out/model_prep/initial/cpu_a/plot_all_valid.dummy
```

This code has been run locally with success.

## Results

### Number of observations by depth in validation set
![obs-count-by-depth-over-valid](https://user-images.githubusercontent.com/11847289/190029532-2b301a02-2346-4962-92e9-4014eb481abf.png)


### Number of observations by day of year in validation set
![obs-count-by-doy-over-valid](https://user-images.githubusercontent.com/11847289/190029559-948c8f40-651c-4f07-a910-0d1c54afc0e1.png)


### Number of observations by elevation in validation set
![obs-count-by-elevation-over-valid](https://user-images.githubusercontent.com/11847289/190029585-65830ab0-bc89-4e66-9a26-1966ec5e1ba8.png)


### Number of observations by area in validation set
![obs-count-by-area-over-valid](https://user-images.githubusercontent.com/11847289/190029611-7167c2f1-f4ab-4d32-a425-7e1b1822d2f5.png)


### Number of observations by day of year and depth in validation set
![obs-count-by-doy_depth-over-valid](https://user-images.githubusercontent.com/11847289/190029628-6ed4510f-24eb-424f-80f7-83e97ddea14e.png)



## How to review this PR

- Are there any obvious errors?
- Any suggested improvements?


### Issues that will be addressed in upcoming PRs (so don't worry about them yet)

- Change to a different plotting library - probably `seaborn`

Closes #49 